### PR TITLE
Add mailmap for contributor mapping

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,5 @@
-Lukas Eberhart <lukas@aau.at> <anonymoushacker0815@users.noreply.github.com>
-Bastian <bastian@aau.at> <bastians99-K9@users.noreply.github.com>
-Christian <christian@aau.at> <ChrisWorkGit@users.noreply.github.com>
-dupetric <dupetric@aau.at> <dupetric@users.noreply.github.com>
-Sebastian Maier <sebastian@aau.at> <sebmaier22@users.noreply.github.com>
+Lukas Eberhart <anonymoushacker0815@users.noreply.github.com> <anonymoushacker0815@users.noreply.github.com>
+Bastian <bastians99-K9@users.noreply.github.com> <bastians99-K9@users.noreply.github.com>
+Christian <ChrisWorkGit@users.noreply.github.com> <ChrisWorkGit@users.noreply.github.com>
+dupetric <dupetric@users.noreply.github.com> <dupetric@users.noreply.github.com>
+Sebastian Maier <sebmaier22@users.noreply.github.com> <sebmaier22@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,10 @@
-Lukas Eberhart <anonymoushacker0815@users.noreply.github.com> <anonymoushacker0815@users.noreply.github.com>
-Bastian <bastians99-K9@users.noreply.github.com> <bastians99-K9@users.noreply.github.com>
-Christian <ChrisWorkGit@users.noreply.github.com> <ChrisWorkGit@users.noreply.github.com>
-dupetric <dupetric@users.noreply.github.com> <dupetric@users.noreply.github.com>
-Sebastian Maier <sebmaier22@users.noreply.github.com> <sebmaier22@users.noreply.github.com>
+Lukas Eberhart <lukaseb@edu.aau.at> Anonymoushacker0815 <eelukasee@gmail.com>
+Lukas Eberhart <lukaseb@edu.aau.at> <106514343+Anonymoushacker0815@users.noreply.github.com>
+
+Bastian Schröder-Possmann <bastiansc@edu.aau.at> Bastian Schroeder <bastian.schroedern99@gmail.com>
+
+Sebastian Maier <sebmaier@edu.aau.at> sebmaier22 <sebmaier@edu.aau.at>
+
+Dusko Petric <dupetric@edu.aau.at> valesco97 <85198263+valesco97@users.noreply.github.com>
+
+Christian Scharf <chscharf@edu.aau.at>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Lukas Eberhart <lukas@aau.at> <anonymoushacker0815@users.noreply.github.com>
+Bastian <bastian@aau.at> <bastians99-K9@users.noreply.github.com>
+Christian <christian@aau.at> <ChrisWorkGit@users.noreply.github.com>
+dupetric <dupetric@aau.at> <dupetric@users.noreply.github.com>
+Sebastian Maier <sebastian@aau.at> <sebmaier22@users.noreply.github.com>

--- a/app/app/src/main/java/com/aau/se2game/MainActivity.kt
+++ b/app/app/src/main/java/com/aau/se2game/MainActivity.kt
@@ -27,6 +27,7 @@ import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
 import com.aau.se2game.ui.theme.SE2GameTheme
+import com.aau.se2game.ui.lobby.LobbyScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -34,7 +35,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             SE2GameTheme {
-                ConnectivityTestScreen(modifier = Modifier.padding(24.dp))
+                LobbyScreen()
             }
         }
     }

--- a/app/app/src/main/java/com/aau/se2game/ui/lobby/LobbyScreen.kt
+++ b/app/app/src/main/java/com/aau/se2game/ui/lobby/LobbyScreen.kt
@@ -1,0 +1,72 @@
+package com.aau.se2game.ui.lobby
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun LobbyScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Lobby",
+            style = MaterialTheme.typography.headlineMedium
+        )
+
+        Button(
+            onClick = { },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Lobby erstellen")
+        }
+
+        Button(
+            onClick = { },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Lobby beitreten")
+        }
+
+        Button(
+            onClick = { },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Lobby suchen")
+        }
+
+        Button(
+            onClick = { },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Aktive Lobbys")
+        }
+
+        Button(
+            onClick = { },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Leute einladen")
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun LobbyScreenPreview() {
+    LobbyScreen()
+}


### PR DESCRIPTION
## Was wurde gemacht

Es wurde eine `.mailmap`-Datei hinzugefügt bzw. korrigiert, um die Contributor-Identitäten im Repository zu vereinheitlichen.

## Warum das notwendig war

In der bisherigen Commit-Historie wurden einige Teammitglieder mehrfach angezeigt, da:
- unterschiedliche E-Mail-Adressen verwendet wurden (z. B. Gmail vs. Uni-Mail)
- GitHub „noreply“-Adressen genutzt wurden
- teilweise Benutzername statt echter Name verwendet wurde

Dadurch sind doppelte Einträge in Logs und Statistiken entstanden.

## Lösung

Mit der `.mailmap` werden alle bekannten Identitäten auf eine einheitliche Darstellung gemappt.

Alle Contributors werden jetzt konsistent angezeigt mit:
- vollständigem Namen
- Uni-Mail-Adresse (`@edu.aau.at`)

## Betroffene Contributors

- Lukas Eberhart  
- Bastian Schröder-Possmann  
- Sebastian Maier  
- Dusko Petric  
- Christian Scharf (für zukünftige Commits vorbereitet)

## Überprüfung

Die Zuordnung wurde lokal überprüft mit:
git check-mailmap "<name> <email>"
git shortlog --all -sne

Alle Mappings funktionieren korrekt.

## Hinweise

- Bestehende Commits werden dadurch **nicht verändert**
- Es wird nur die Anzeige/Zuordnung in Git verbessert
- Für zukünftige Commits sollten alle die Uni-Mail verwenden, um weitere Inkonsistenzen zu vermeiden
