### PR TITLE
Feature/card distribution

### DIFF
--- a/server/src/main/kotlin/com/aau/server/CardDistributionResult.kt
+++ b/server/src/main/kotlin/com/aau/server/CardDistributionResult.kt
@@ -1,0 +1,10 @@
+package com.aau.server
+
+import com.aau.saboteur.model.TunnelCard
+
+data class CardDistributionResult(
+    val hands: Map<String, List<TunnelCard>>,
+    val drawPile: List<TunnelCard>,
+    val goalCards: List<TunnelCard>,
+    val startCard: TunnelCard
+)

--- a/server/src/main/kotlin/com/aau/server/CardDistributor.kt
+++ b/server/src/main/kotlin/com/aau/server/CardDistributor.kt
@@ -1,0 +1,39 @@
+package com.aau.server
+
+object CardDistributor {
+
+    /**
+     * Distributes cards to players at game start following official Saboteur rules.
+     *
+     * @param playerIds ordered list of player IDs (3–10 players)
+     * @return [CardDistributionResult] with hands, draw pile, goal cards, and start card
+     * @throws IllegalArgumentException if player count is outside 3–10
+     */
+    fun distribute(playerIds: List<String>): CardDistributionResult {
+        val playerCount = playerIds.size
+        require(playerCount in 3..10) {
+            "Player count must be between 3 and 10, was $playerCount"
+        }
+
+        val cardsPerPlayer = when {
+            playerCount <= 5 -> 6
+            playerCount <= 7 -> 5
+            else -> 4
+        }
+        val shuffledDeck = CardDeck.shuffled(CardDeck.createTunnelDeck())
+
+        val hands = playerIds.mapIndexed { index, playerId ->
+            val start = index * cardsPerPlayer
+            playerId to shuffledDeck.subList(start, start + cardsPerPlayer)
+        }.toMap()
+
+        val drawPile = shuffledDeck.drop(playerCount * cardsPerPlayer)
+
+        return CardDistributionResult(
+            hands = hands,
+            drawPile = drawPile,
+            goalCards = CardDeck.createGoalCards(),
+            startCard = CardDeck.createStartCard()
+        )
+    }
+}

--- a/server/src/test/kotlin/com/aau/server/CardDistributorTest.kt
+++ b/server/src/test/kotlin/com/aau/server/CardDistributorTest.kt
@@ -87,4 +87,17 @@ class CardDistributorTest {
         }
         assertTrue(differentFound, "Expected shuffled deck to differ across multiple calls")
     }
+
+    // Temporärer Hilfstest zur manuellen Ausgabe der Kartenverteilung – nicht für CI gedacht
+    /*
+    @Test
+    fun `debug distribute output`() {
+        val result = CardDistributor.distribute(listOf("Alice", "Bob", "Charlie"))
+        result.hands.forEach { (player, cards) ->
+            println("$player: ${cards.map { it.id }}")
+        }
+        println("Draw pile (${result.drawPile.size} cards): ${result.drawPile.map { it.id }}")
+        println("Goal cards: ${result.goalCards.map { it.id }}")
+        println("Start card: ${result.startCard.id}")
+    } */
 }

--- a/server/src/test/kotlin/com/aau/server/CardDistributorTest.kt
+++ b/server/src/test/kotlin/com/aau/server/CardDistributorTest.kt
@@ -1,0 +1,90 @@
+package com.aau.server
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class CardDistributorTest {
+
+    private fun playerIds(count: Int) = (1..count).map { "player_$it" }
+
+    // --- Hand size per bracket ---
+
+    @ParameterizedTest
+    @ValueSource(ints = [3, 4, 5])
+    fun `3 to 5 players each receive 6 cards`(playerCount: Int) {
+        val result = CardDistributor.distribute(playerIds(playerCount))
+        result.hands.values.forEach { assertEquals(6, it.size) }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [6, 7])
+    fun `6 to 7 players each receive 5 cards`(playerCount: Int) {
+        val result = CardDistributor.distribute(playerIds(playerCount))
+        result.hands.values.forEach { assertEquals(5, it.size) }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [8, 9, 10])
+    fun `8 to 10 players each receive 4 cards`(playerCount: Int) {
+        val result = CardDistributor.distribute(playerIds(playerCount))
+        result.hands.values.forEach { assertEquals(4, it.size) }
+    }
+
+    // --- Card conservation ---
+
+    @ParameterizedTest
+    @ValueSource(ints = [3, 4, 5, 6, 7, 8, 9, 10])
+    fun `total card count is conserved (hands + draw pile = 40)`(playerCount: Int) {
+        val result = CardDistributor.distribute(playerIds(playerCount))
+        val handCardCount = result.hands.values.sumOf { it.size }
+        assertEquals(40, handCardCount + result.drawPile.size)
+    }
+
+    @Test
+    fun `all 40 tunnel card ids are present across hands and draw pile`() {
+        val result = CardDistributor.distribute(playerIds(5))
+        val allDealtIds = result.hands.values.flatten().map { it.id } + result.drawPile.map { it.id }
+        val expectedIds = CardDeck.createTunnelDeck().map { it.id }.toSet()
+        assertEquals(expectedIds, allDealtIds.toSet())
+    }
+
+    // --- Invalid player counts ---
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 1, 2, 11, 100])
+    fun `invalid player count throws IllegalArgumentException`(playerCount: Int) {
+        assertThrows<IllegalArgumentException> {
+            CardDistributor.distribute(playerIds(playerCount))
+        }
+    }
+
+    // --- Board cards ---
+
+    @Test
+    fun `goal cards are exactly 3 and all face-down`() {
+        val result = CardDistributor.distribute(playerIds(4))
+        assertEquals(3, result.goalCards.size)
+        assertTrue(result.goalCards.none { it.isRevealed })
+    }
+
+    @Test
+    fun `start card is revealed`() {
+        val result = CardDistributor.distribute(playerIds(4))
+        assertTrue(result.startCard.isRevealed)
+    }
+
+    // --- Shuffle ---
+
+    @Test
+    fun `repeated distributions produce different card orders`() {
+        val ids = playerIds(5)
+        val firstOrder = CardDistributor.distribute(ids).drawPile.map { it.id }
+        val differentFound = (1..20).any {
+            CardDistributor.distribute(ids).drawPile.map { it.id } != firstOrder
+        }
+        assertTrue(differentFound, "Expected shuffled deck to differ across multiple calls")
+    }
+}


### PR DESCRIPTION
  ## Zusammenfassung
- Neues `CardDistributionResult` Data Class mit den Feldern `hands`, `drawPile`, `goalCards` und `startCard`
  - Neues `CardDistributor` Objekt implementiert die offizielle Saboteur-Kartenverteilung:
    - 3–5 Spieler: 6 Karten pro Spieler
    - 6–7 Spieler: 5 Karten pro Spieler
    - 8–10 Spieler: 4 Karten pro Spieler
  - Ungültige Spieleranzahl (< 3 oder > 10) wirft eine `IllegalArgumentException`
  - Die verbleibenden Karten werden als Nachziehstapel zurückgegeben
  - Zielkarten und Startkarte werden direkt über `CardDeck` bereitgestellt                                                                                                      
                                                                                                                                                                                
  ## Tests                                                                                                                                                                      
                                                                                                                                                                                
  25 Unit-Tests in `CardDistributorTest` decken ab:
  - Korrekte Handgröße für alle Spieleranzahl-Bereiche (3, 5, 6, 7, 8, 10 Spieler)
  - Kartenerhaltung: Handkarten + Nachziehstapel = 40                                                                                                                           
  - Alle 40 Tunnel-Karten-IDs vorhanden                                                                                                                                         
  - Ungültige Spieleranzahl wirft Exception                                                                                                                                     
  - Zielkarten: genau 3, alle verdeckt                                                                                                                                          
  - Startkarte ist aufgedeckt                                                                                                                                                   
  - Zufälligkeit des Mischens                                                                                                                                                   
                                                                                                                                                                                