### PR TITLE
Add Docker deployment with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [ "main" ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Build with Gradle
+        run: ./gradlew :server:build -x test
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./server/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
+
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -19,15 +20,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
       - name: Build with Gradle
-        run: ./gradlew :server:build -x test
+
+        run: ./gradlew :server:bootJar -x test
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -42,4 +47,5 @@ jobs:
           context: .
           file: ./server/Dockerfile
           push: true
+
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  server:
+    image: ghcr.io/se2gruppe3/saboteur:latest
+    restart: unless-stopped
+    ports:
+      - "53207:8080"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,3 +4,5 @@ services:
     restart: unless-stopped
     ports:
       - "53207:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,13 +1,10 @@
 FROM eclipse-temurin:17-jdk-alpine
-
-
 WORKDIR /app
 
 
-COPY server/build/libs/*.jar app.jar
+COPY server/build/libs/server.jar app.jar
 
 
 EXPOSE 8080
 
-hl
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,13 @@
+FROM eclipse-temurin:17-jdk-alpine
+
+
+WORKDIR /app
+
+
+COPY server/build/libs/*.jar app.jar
+
+
+EXPOSE 8080
+
+hl
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -75,4 +75,9 @@ sonar {
 		property("sonar.projectName", "saboteur-server")
 		property("sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml")
 	}
+
+
+}
+tasks.named<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {
+	archiveFileName.set("server.jar")
 }


### PR DESCRIPTION
#61 Dieses PR führt die Containerisierung des Backends ein und setzt die CI/CD-Pipeline für das automatische Deployment auf den Uni-Server (`se2-demo.aau.at`) auf.

## Änderungen
- **Dockerfile:** Im `server`-Modul erstellt, um die Spring Boot Anwendung (inkl. Shared-Modul) in einem Java 17 Alpine Image zu kapseln.
- **GitHub Actions:** Workflow `.github/workflows/deploy.yml` hinzugefügt. Dieser baut bei jedem Push auf `main` das Projekt mit Gradle und schiebt das fertige Image in die GitHub Container Registry (ghcr.io).
- **Docker Compose:** `docker-compose.yaml` im Root-Verzeichnis hinzugefügt, um den Container-Start und das Port-Mapping (Port 53207 für Gruppe 3) zu definieren.

## Technischer Hintergrund
- Das `shared`-Modul wird während des Gradle-Builds automatisch in die Server-JAR integriert.
- Die Registry nutzt das Image `ghcr.io/se2gruppe3/saboteur:latest`.
