### PR TITLE
Feature/board UI

### DIFF
--- a/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
@@ -75,6 +75,22 @@ private val TileElevation = 4.dp
 private val TileBorderWidth = 2.dp
 private val TileContentPadding = 6.dp
 
+/**
+ * Scrollbares, zoombares Spielfeld für Saboteur.
+ *
+ * Zeigt ein [BoardColumns]×[BoardRows]-Raster aus [BoardTile]-Kacheln.
+ * Gelegte Karten werden anhand ihrer [BoardPosition] aus [placements] gesucht;
+ * leere Zellen erscheinen als leere Kacheln.
+ *
+ * **Gesten**
+ * - Einfingeriges Wischen → scrollt das Raster horizontal und vertikal.
+ * - Zwei-Finger-Pinch → zoomt zwischen [MinBoardZoom] und [MaxBoardZoom].
+ *   Der Zoom skaliert die Kacheln direkt (kein `graphicsLayer`), damit der
+ *   Scroll-Bereich mit dem sichtbaren Inhalt übereinstimmt.
+ *
+ * @param placements Liste aller bereits gelegten Karten mit Position.
+ * @param modifier Wird an die äußere [Surface] weitergegeben.
+ */
 @Composable
 fun BoardGrid(
     placements: List<PlacedTunnelCard>,

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
@@ -55,8 +55,8 @@ import com.aau.saboteur.ui.toContentDescription
 import com.aau.saboteur.ui.toDrawableName
 import kotlin.math.hypot
 
-private const val BoardColumns = 9
-private const val BoardRows = 13
+private const val BoardColumns = 13
+private const val BoardRows = 9
 private const val BackgroundGridColumns = (BoardColumns + 1) * 3
 private const val BackgroundGridRows = (BoardRows + 1) * 3
 private const val BoardCardWidthDp = 86

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
@@ -80,7 +80,6 @@ private val TileContentPadding = 6.dp
 @Composable
 fun BoardGrid(
     placements: List<PlacedTunnelCard>,
-    startPosition: BoardPosition,
     modifier: Modifier = Modifier
 ) {
     val horizontalScroll = rememberScrollState()

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -41,6 +40,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.aau.saboteur.model.BoardPosition
 import com.aau.saboteur.model.CardType
@@ -89,12 +89,14 @@ private val TileContentPadding = 6.dp
  *   Scroll-Bereich mit dem sichtbaren Inhalt übereinstimmt.
  *
  * @param placements Liste aller bereits gelegten Karten mit Position.
+ * @param onCellClick Wird aufgerufen, wenn der Spieler eine Zelle antippt. Liefert die [BoardPosition] der angeklickten Zelle.
  * @param modifier Wird an die äußere [Surface] weitergegeben.
  */
 @Composable
 fun BoardGrid(
     placements: List<PlacedTunnelCard>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onCellClick: (BoardPosition) -> Unit = {},
 ) {
     val horizontalScroll = rememberScrollState()
     val verticalScroll = rememberScrollState()
@@ -174,18 +176,17 @@ fun BoardGrid(
                         }
                     }
 
-                    Column(
-                        modifier = Modifier.fillMaxSize(),
-                        verticalArrangement = Arrangement.spacedBy(BoardCardSpacingDp.dp)
-                    ) {
+                    Column(modifier = Modifier.fillMaxSize()) {
                         repeat(BoardRows) { row ->
-                            Row(horizontalArrangement = Arrangement.spacedBy(BoardCardSpacingDp.dp)) {
+                            Row {
                                 repeat(BoardColumns) { column ->
-                                    val placement = placementMap[BoardPosition(row = row, column = column)]
+                                    val position = BoardPosition(row = row, column = column)
+                                    val placement = placementMap[position]
                                     BoardTile(
                                         card = placement?.card,
                                         cardWidth = scaledCardWidth,
-                                        cardHeight = scaledCardHeight
+                                        cardHeight = scaledCardHeight,
+                                        onClick = { onCellClick(position) }
                                     )
                                 }
                             }
@@ -200,8 +201,9 @@ fun BoardGrid(
 @Composable
 private fun BoardTile(
     card: TunnelCard?,
-    cardWidth: androidx.compose.ui.unit.Dp = BoardCardWidthDp.dp,
-    cardHeight: androidx.compose.ui.unit.Dp = BoardCardHeightDp.dp,
+    cardWidth: Dp = BoardCardWidthDp.dp,
+    cardHeight: Dp = BoardCardHeightDp.dp,
+    onClick: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val drawableName = card?.toDrawableName()
@@ -211,6 +213,7 @@ private fun BoardTile(
     } ?: 0
 
     Card(
+        onClick = onClick,
         modifier = Modifier.size(width = cardWidth, height = cardHeight),
         shape = BoardShape,
         elevation = CardDefaults.cardElevation(defaultElevation = TileElevation),
@@ -344,6 +347,7 @@ private fun tileBorderColor(card: TunnelCard?): Color = when {
 }
 
 private fun List<PointerInputChange>.pointerDistance(usePreviousPosition: Boolean): Float {
+    require(size >= 2) { "pointerDistance requires at least 2 pointers, got $size" }
     val firstPosition  = if (usePreviousPosition) this[0].previousPosition else this[0].position
     val secondPosition = if (usePreviousPosition) this[1].previousPosition else this[1].position
     return hypot(

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
@@ -99,16 +99,6 @@ fun BoardGrid(
                 .heightIn(min = BoardMinHeight, max = BoardDefaultHeight)
                 .padding(BoardOuterPadding)
         ) {
-            // ── FIX: scrollable area grows/shrinks with zoom ──────────────────
-            // graphicsLayer skaliert nur visuell – der belegte Platz bleibt gleich.
-            // Deshalb geben wir der inneren Box die bereits skalierten Dimensionen
-            // als tatsächliche Größe mit, und verschieben den Inhalt per graphicsLayer
-            // ohne TransformOrigin-Trick (origin bleibt 0,0 damit Scroll-Koordinaten
-            // übereinstimmen).
-            // FIX: Tile-Größen direkt skalieren statt graphicsLayer zu verwenden.
-            // graphicsLayer skaliert nur visuell – Layout-Platz und Scroll-Bereich
-            // bleiben unverändert → brauner Rand beim Rauszoomen, Clipping beim Reinzoomen.
-            // Wenn die Tiles selbst skaliert werden, stimmt alles automatisch überein.
             val scaledCardWidth  = (BoardCardWidthDp  * scale).dp
             val scaledCardHeight = (BoardCardHeightDp * scale).dp
             val scaledWidth      = (BoardContentWidthDp  * scale).dp
@@ -123,7 +113,7 @@ fun BoardGrid(
                             verticalScroll.dispatchRawDelta(-dragAmount.y)
                         }
                     }
-                    .pointerInput(scale) {
+                    .pointerInput(Unit) {
                         awaitEachGesture {
                             do {
                                 val event = awaitPointerEvent()
@@ -190,10 +180,6 @@ fun BoardGrid(
         }
     }
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Alle anderen Composables & Hilfsfunktionen unverändert
-// ─────────────────────────────────────────────────────────────────────────────
 
 @Composable
 private fun BoardTile(

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -17,18 +20,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -42,7 +41,6 @@ import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -61,7 +59,7 @@ private const val BackgroundGridColumns = (BoardColumns + 1) * 3
 private const val BackgroundGridRows = (BoardRows + 1) * 3
 private const val BoardCardWidthDp = 86
 private const val BoardCardHeightDp = 126
-private const val BoardCardSpacingDp = 12
+private const val BoardCardSpacingDp = 0
 private const val BoardContentWidthDp = BoardColumns * BoardCardWidthDp + (BoardColumns - 1) * BoardCardSpacingDp
 private const val BoardContentHeightDp = BoardRows * BoardCardHeightDp + (BoardRows - 1) * BoardCardSpacingDp
 private const val BoardGridLineAlpha = 0.28f
@@ -89,7 +87,6 @@ fun BoardGrid(
     val verticalScroll = rememberScrollState()
     val placementMap = placements.associateBy(PlacedTunnelCard::position)
     val lineColor = MaterialTheme.colorScheme.outline.copy(alpha = BoardGridLineAlpha)
-    var didInitialScroll by remember { mutableStateOf(false) }
     var scale by remember { mutableFloatStateOf(1f) }
 
     Surface(
@@ -105,40 +102,17 @@ fun BoardGrid(
                 .heightIn(min = BoardMinHeight, max = BoardDefaultHeight)
                 .padding(BoardOuterPadding)
         ) {
-            val density = LocalDensity.current
-            val viewportWidthPx = constraints.maxWidth
-            val viewportHeightPx = constraints.maxHeight
-
-            LaunchedEffect(viewportWidthPx, viewportHeightPx, startPosition) {
-                if (didInitialScroll) return@LaunchedEffect
-
-                val cardWidthPx = with(density) { BoardCardWidthDp.dp.roundToPx() }
-                val cardHeightPx = with(density) { BoardCardHeightDp.dp.roundToPx() }
-                val spacingPx = with(density) { BoardCardSpacingDp.dp.roundToPx() }
-                val cellWidthPx = cardWidthPx + spacingPx
-                val cellHeightPx = cardHeightPx + spacingPx
-                val contentWidthPx = with(density) { BoardContentWidthDp.dp.roundToPx() }
-                val contentHeightPx = with(density) { BoardContentHeightDp.dp.roundToPx() }
-                val startCenterX = startPosition.column * cellWidthPx + cardWidthPx / 2
-                val startCenterY = startPosition.row * cellHeightPx + cardHeightPx / 2
-                val targetX = (startCenterX - viewportWidthPx / 2).coerceIn(
-                    0,
-                    (contentWidthPx - viewportWidthPx).coerceAtLeast(0)
-                )
-                val targetY = (startCenterY - viewportHeightPx / 2).coerceIn(
-                    0,
-                    (contentHeightPx - viewportHeightPx).coerceAtLeast(0)
-                )
-                horizontalScroll.scrollTo(targetX)
-                verticalScroll.scrollTo(targetY)
-                didInitialScroll = true
-            }
-
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .verticalScroll(verticalScroll)
-                    .horizontalScroll(horizontalScroll)
+                    .pointerInput(Unit) {
+                        detectDragGestures { _, dragAmount ->
+                            horizontalScroll.dispatchRawDelta(-dragAmount.x)
+                            verticalScroll.dispatchRawDelta(-dragAmount.y)
+                        }
+                    }
+                    .verticalScroll(verticalScroll, enabled = false)
+                    .horizontalScroll(horizontalScroll, enabled = false)
             ) {
                 Box(
                     modifier = Modifier

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -94,7 +93,7 @@ fun BoardGrid(
         tonalElevation = BoardTonalElevation,
         shadowElevation = BoardShadowElevation
     ) {
-        BoxWithConstraints(
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(min = BoardMinHeight, max = BoardDefaultHeight)
@@ -204,6 +203,7 @@ private fun BoardTile(
 ) {
     val context = LocalContext.current
     val drawableName = card?.toDrawableName()
+    @Suppress("DiscouragedApi")
     val imageRes = drawableName?.let {
         context.resources.getIdentifier(it, "drawable", context.packageName)
     } ?: 0

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
@@ -101,6 +100,21 @@ fun BoardGrid(
                 .heightIn(min = BoardMinHeight, max = BoardDefaultHeight)
                 .padding(BoardOuterPadding)
         ) {
+            // ── FIX: scrollable area grows/shrinks with zoom ──────────────────
+            // graphicsLayer skaliert nur visuell – der belegte Platz bleibt gleich.
+            // Deshalb geben wir der inneren Box die bereits skalierten Dimensionen
+            // als tatsächliche Größe mit, und verschieben den Inhalt per graphicsLayer
+            // ohne TransformOrigin-Trick (origin bleibt 0,0 damit Scroll-Koordinaten
+            // übereinstimmen).
+            // FIX: Tile-Größen direkt skalieren statt graphicsLayer zu verwenden.
+            // graphicsLayer skaliert nur visuell – Layout-Platz und Scroll-Bereich
+            // bleiben unverändert → brauner Rand beim Rauszoomen, Clipping beim Reinzoomen.
+            // Wenn die Tiles selbst skaliert werden, stimmt alles automatisch überein.
+            val scaledCardWidth  = (BoardCardWidthDp  * scale).dp
+            val scaledCardHeight = (BoardCardHeightDp * scale).dp
+            val scaledWidth      = (BoardContentWidthDp  * scale).dp
+            val scaledHeight     = (BoardContentHeightDp * scale).dp
+
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -110,35 +124,28 @@ fun BoardGrid(
                             verticalScroll.dispatchRawDelta(-dragAmount.y)
                         }
                     }
+                    .pointerInput(scale) {
+                        awaitEachGesture {
+                            do {
+                                val event = awaitPointerEvent()
+                                val pressedChanges = event.changes.filter(PointerInputChange::pressed)
+                                if (pressedChanges.size >= 2) {
+                                    val previousDistance = pressedChanges.pointerDistance(usePreviousPosition = true)
+                                    val currentDistance  = pressedChanges.pointerDistance(usePreviousPosition = false)
+                                    if (previousDistance > 0f) {
+                                        val zoomChange = currentDistance / previousDistance
+                                        scale = (scale * zoomChange).coerceIn(MinBoardZoom, MaxBoardZoom)
+                                    }
+                                    pressedChanges.forEach(PointerInputChange::consume)
+                                }
+                            } while (event.changes.any(PointerInputChange::pressed))
+                        }
+                    }
                     .verticalScroll(verticalScroll, enabled = false)
                     .horizontalScroll(horizontalScroll, enabled = false)
             ) {
-                Box(
-                    modifier = Modifier
-                        .size(width = BoardContentWidthDp.dp, height = BoardContentHeightDp.dp)
-                        .graphicsLayer {
-                            scaleX = scale
-                            scaleY = scale
-                            transformOrigin = TransformOrigin(0f, 0f)
-                        }
-                        .pointerInput(Unit) {
-                            awaitEachGesture {
-                                do {
-                                    val event = awaitPointerEvent()
-                                    val pressedChanges = event.changes.filter(PointerInputChange::pressed)
-                                    if (pressedChanges.size >= 2) {
-                                        val previousDistance = pressedChanges.pointerDistance(usePreviousPosition = true)
-                                        val currentDistance = pressedChanges.pointerDistance(usePreviousPosition = false)
-                                        if (previousDistance > 0f) {
-                                            val zoomChange = currentDistance / previousDistance
-                                            scale = (scale * zoomChange).coerceIn(MinBoardZoom, MaxBoardZoom)
-                                        }
-                                        pressedChanges.forEach(PointerInputChange::consume)
-                                    }
-                                } while (event.changes.any(PointerInputChange::pressed))
-                            }
-                        }
-                ) {
+                // Tatsächliche Größe = skaliert → Scroll-Bereich wächst/schrumpft korrekt
+                Box(modifier = Modifier.size(width = scaledWidth, height = scaledHeight)) {
                     Canvas(modifier = Modifier.fillMaxSize()) {
                         val spacing = size.width / BackgroundGridColumns
                         repeat(BackgroundGridColumns + 1) { index ->
@@ -170,7 +177,11 @@ fun BoardGrid(
                             Row(horizontalArrangement = Arrangement.spacedBy(BoardCardSpacingDp.dp)) {
                                 repeat(BoardColumns) { column ->
                                     val placement = placementMap[BoardPosition(row = row, column = column)]
-                                    BoardTile(card = placement?.card)
+                                    BoardTile(
+                                        card = placement?.card,
+                                        cardWidth = scaledCardWidth,
+                                        cardHeight = scaledCardHeight
+                                    )
                                 }
                             }
                         }
@@ -181,8 +192,16 @@ fun BoardGrid(
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Alle anderen Composables & Hilfsfunktionen unverändert
+// ─────────────────────────────────────────────────────────────────────────────
+
 @Composable
-private fun BoardTile(card: TunnelCard?) {
+private fun BoardTile(
+    card: TunnelCard?,
+    cardWidth: androidx.compose.ui.unit.Dp = BoardCardWidthDp.dp,
+    cardHeight: androidx.compose.ui.unit.Dp = BoardCardHeightDp.dp,
+) {
     val context = LocalContext.current
     val drawableName = card?.toDrawableName()
     val imageRes = drawableName?.let {
@@ -190,7 +209,7 @@ private fun BoardTile(card: TunnelCard?) {
     } ?: 0
 
     Card(
-        modifier = Modifier.size(width = BoardCardWidthDp.dp, height = BoardCardHeightDp.dp),
+        modifier = Modifier.size(width = cardWidth, height = cardHeight),
         shape = BoardShape,
         elevation = CardDefaults.cardElevation(defaultElevation = TileElevation),
         colors = CardDefaults.cardColors(containerColor = tileColor(card))
@@ -323,7 +342,7 @@ private fun tileBorderColor(card: TunnelCard?): Color = when {
 }
 
 private fun List<PointerInputChange>.pointerDistance(usePreviousPosition: Boolean): Float {
-    val firstPosition = if (usePreviousPosition) this[0].previousPosition else this[0].position
+    val firstPosition  = if (usePreviousPosition) this[0].previousPosition else this[0].position
     val secondPosition = if (usePreviousPosition) this[1].previousPosition else this[1].position
     return hypot(
         x = secondPosition.x - firstPosition.x,

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -61,7 +61,6 @@ fun GameScreen(
             ) {
                 BoardGrid(
                     placements = uiState.gameState.boardPlacements,
-                    startPosition = uiState.gameState.boardStartPosition,
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f)

--- a/server/src/main/kotlin/com/aau/server/service/GameService.kt
+++ b/server/src/main/kotlin/com/aau/server/service/GameService.kt
@@ -68,19 +68,19 @@ class GameService {
         val goalCards = CardDeck.createGoalCards().shuffled()
         return listOf(
             PlacedTunnelCard(
-                position = BoardPosition(row = 0, column = 2),
+                position = BoardPosition(row = 2, column = 10),
                 card = goalCards[0]
             ),
             PlacedTunnelCard(
-                position = BoardPosition(row = 0, column = 4),
+                position = BoardPosition(row = 4, column = 10),
                 card = goalCards[1]
             ),
             PlacedTunnelCard(
-                position = BoardPosition(row = 0, column = 6),
+                position = BoardPosition(row = 6, column = 10),
                 card = goalCards[2]
             ),
             PlacedTunnelCard(
-                position = BoardPosition(row = 10, column = 4),
+                position = BoardPosition(row = 4, column = 2),
                 card = CardDeck.createStartCard()
             )
         )

--- a/shared/src/commonMain/kotlin/com/aau/saboteur/model/GameState.kt
+++ b/shared/src/commonMain/kotlin/com/aau/saboteur/model/GameState.kt
@@ -6,6 +6,5 @@ import kotlinx.serialization.Serializable
 data class GameState(
     val players: List<PlayerTurn> = emptyList(),
     val currentPlayerId: String? = null,
-    val boardPlacements: List<PlacedTunnelCard> = emptyList(),
-    val boardStartPosition: BoardPosition = BoardPosition(row = 10, column = 4)
+    val boardPlacements: List<PlacedTunnelCard> = emptyList()
 )


### PR DESCRIPTION
## Zusammenfassung                                                                                                                                                            
                                                                                                                                                                                
  - Board-Layout von 9×13 auf 13×9 rotiert und alle initialen Kartenposition angepasst (Startkarte links-mitte, 3 Zielkarten rechts-mitte)                                      
  - `BoxWithConstraints`-basiertes Scroll/Zoom durch sauberes `Box`-Setup ersetzt: Einfingeriges Wischen via `detectDragGestures` + `dispatchRawDelta`, Pinch-to-Zoom durch
  direktes Skalieren der Kacheln (kein `graphicsLayer`), damit Scroll-Bereich und sichtbarer Inhalt immer übereinstimmen                                                        
  - Freies diagonales Panning aktiviert — horizontaler und vertikaler Scroll werden programmatisch gesteuert, eingebautes Touch-Handling deaktiviert
  - Toter Code entfernt: `startPosition`-Parameter aus `BoardGrid`, `boardStartPosition`-Feld aus `GameState`                                                                   
  - Zoom-Stottern behoben: `pointerInput(scale)` → `pointerInput(Unit)` mit direktem State-Zugriff                                                                              
  - KDoc für `BoardGrid` hinzugefügt                                                                                                                                            
                                                                                                                                                                                
  ## Testplan                                                                                                                                                                   
                  
  - [ ] Board rendert korrekt als 13×9 (Startkarte links-mitte, Zielkarten rechts-mitte)                                                                                        
  - [ ] Einfingeriges Wischen scrollt in alle Richtungen
  - [ ] Pinch-to-Zoom skaliert zwischen 0,75× und 2,0×; Scroll-Bereich wächst/schrumpft mit dem Zoom (kein brauner Rand, kein Clipping)                                         
  - [ ] Pan und Zoom kombiniert nutzbar ohne Stottern                                                                                                                           
  - [ ] Keine Regressionen in anderen Screens (Lobby, Login, Menu) 