### PR TITLE
fix(game-api): set replay=1 on _cardsDealtUpdates to restore hand car…

### DIFF
--- a/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
+++ b/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
@@ -23,7 +23,7 @@ object GameApi {
 
     private val _playerUpdates = MutableSharedFlow<Player>(replay = 1, extraBufferCapacity = 10)
     val playerUpdates: SharedFlow<Player> = _playerUpdates.asSharedFlow()
-    private val _cardsDealtUpdates = MutableSharedFlow<Map<String, List<TunnelCard>>>(replay = 0, extraBufferCapacity = 10)
+    private val _cardsDealtUpdates = MutableSharedFlow<Map<String, List<TunnelCard>>>(replay = 1, extraBufferCapacity = 10)
     val cardsDealtUpdates: SharedFlow<Map<String, List<TunnelCard>>> = _cardsDealtUpdates.asSharedFlow()
 
     val errorMessages: SharedFlow<String> = WebSocketManager.errorMessages
@@ -75,5 +75,6 @@ object GameApi {
     fun reset() {
         _gameStateUpdates.resetReplayCache()
         _playerUpdates.resetReplayCache()
+        _cardsDealtUpdates.resetReplayCache()
     }
 }


### PR DESCRIPTION
 ##Beschreibung:
 #Problem
Wenn der User nach „Start Game" ins Menü navigiert und über den „Game"-Button zurückkehrt, legt Compose Navigation einen neuen Back-Stack-Eintrag mit einem frischen GameViewModel an. Dieses neue ViewModel subscribed zu cardsDealtUpdates, jedoch hatte _cardsDealtUpdates replay = 0 — dadurch kam kein Wert beim neuen Subscriber an, hands blieb null und die Handkarten wurden nicht angezeigt.

 #Ursache
_cardsDealtUpdates in GameApi.kt war als MutableSharedFlow(replay = 0) konfiguriert, während alle anderen Flows bereits replay = 1 verwenden.

 #Fix
replay = 0 → replay = 1 bei _cardsDealtUpdates, sodass der zuletzt ausgeteilte Kartensatz sofort an neue Subscriber weitergegeben wird.
reset() leert nun zusätzlich den Karten-Cache, damit beim Neustart einer Runde keine Daten aus der vorherigen Partie erscheinen.

 #Getestet:
 Handkarten erscheinen nach Navigation zurück ins Spiel korrekt