### PR TITLE
complete production setup with env variables and build variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ capture/
 *.ap_
 *.apk
 *.dex
+
+.env

--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -35,7 +35,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            buildConfigField("String", "BASE_URL", "\"https://your-production-url.com\"")
+            buildConfigField("String", "BASE_URL", "\"http://se2-demo.aau.at:53207\"")
         }
     }
     compileOptions {

--- a/app/app/src/main/java/com/aau/saboteur/data/repository/AuthRepository.kt
+++ b/app/app/src/main/java/com/aau/saboteur/data/repository/AuthRepository.kt
@@ -1,5 +1,6 @@
 package com.aau.saboteur.data.repository
 
+import com.aau.saboteur.BuildConfig
 import com.aau.saboteur.model.User
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -23,7 +24,7 @@ class AuthRepository {
             """.trimIndent().toRequestBody("application/json".toMediaType())
 
             val request = Request.Builder()
-                .url("http://10.0.2.2:8080/api/auth/login")
+                .url("${BuildConfig.BASE_URL}/api/auth/login")
                 .post(requestBodyJson)
                 .build()
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,9 @@ services:
     image: ghcr.io/se2gruppe3/saboteur:latest
     restart: unless-stopped
     ports:
-      - "53207:8080"
+      - "53207:${SERVER_PORT}"
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_DATASOURCE_URL=${DB_URL}
+      - SPRING_DATASOURCE_USERNAME=${DB_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${DB_PASSWORD}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -3,8 +3,8 @@ spring.application.name=server
 # H2 Konfiguration - Speichert die DB in den Ordner "data" im Projekt
 spring.datasource.url=jdbc:h2:file:./data/saboteur_db
 spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=password
+spring.datasource.username=${DB_USERNAME:sa}
+spring.datasource.password=${DB_PASSWORD:password}
 
 # H2 Konsole (erreichbar unter localhost:8080/h2-console)
 spring.h2.console.enabled=true


### PR DESCRIPTION
1. Android App (Build Variants & BuildConfig)

Die BASE_URL wird nicht mehr hart im Code hinterlegt.

In der build.gradle.kts wurden buildConfigFields eingeführt:

Debug: Verwendet weiterhin [http://10.0.2.2:8080](http://10.0.2.2:8080) für lokale Tests im Emulator.

Release: Verwendet automatisch [http://se2-demo.aau.at:53207](http://se2-demo.aau.at:53207) für das Uni-Deployment.

Das AuthRepository nutzt nun BuildConfig.BASE_URL, wodurch die App ohne Code-Änderungen zwischen Umgebungen wechseln kann.

2. Server & Sicherheit (Environment Variables)

Secrets: In der application.properties wurden die harten Zugangsdaten für die Datenbank durch Platzhalter mit Default-Werten ersetzt (${DB_USERNAME:sa}).

Docker Compose: Die docker-compose.yaml wurde so angepasst, dass sie Variablen aus einer .env-Datei lädt. Dies ermöglicht ein sicheres Management von Passwörtern direkt auf dem Server, ohne diese ins Git-Repository einzuchecken.

.gitignore: Die .env-Datei wurde zur .gitignore hinzugefügt, um versehentliche Leaks von Secrets zu verhindern.