### PR TITLE
Feature/turn management v2

### DIFF
--- a/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
+++ b/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
@@ -1,7 +1,10 @@
 package com.aau.saboteur.network.game
 
+import com.aau.saboteur.model.BoardPosition
 import com.aau.saboteur.model.CreateGameRequest
+import com.aau.saboteur.model.DiscardCardRequest
 import com.aau.saboteur.model.GameState
+import com.aau.saboteur.model.PlayCardRequest
 import com.aau.saboteur.model.Player
 import com.aau.saboteur.model.TunnelCard
 import com.aau.saboteur.network.WebSocketManager
@@ -58,7 +61,16 @@ object GameApi {
 
     fun startGame(players: List<Player>) {
         val request = CreateGameRequest(players = players)
-        val data = JSONObject(request.toJson())
-        WebSocketManager.sendMessage("START_GAME", data)
+        WebSocketManager.sendMessage("START_GAME", JSONObject(request.toJson()))
+    }
+
+    fun playCard(playerId: String, cardId: String, position: BoardPosition, isRotated: Boolean) {
+        val request = PlayCardRequest(playerId, cardId, position, isRotated)
+        WebSocketManager.sendMessage("PLAY_CARD", JSONObject(request.toJson()))
+    }
+
+    fun discardCard(playerId: String, cardId: String) {
+        val request = DiscardCardRequest(playerId, cardId)
+        WebSocketManager.sendMessage("DISCARD_CARD", JSONObject(request.toJson()))
     }
 }

--- a/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
+++ b/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
@@ -11,8 +11,11 @@ import com.aau.saboteur.network.WebSocketManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.json.JSONObject
@@ -29,8 +32,9 @@ object GameApi {
     private val _cardsDealtUpdates = MutableStateFlow<Map<String, List<TunnelCard>>?>(null)
     val cardsDealtUpdates: StateFlow<Map<String, List<TunnelCard>>?> = _cardsDealtUpdates.asStateFlow()
 
-    private val _errorMessages = MutableStateFlow<String?>(null)
-    val errorMessages: StateFlow<String?> = _errorMessages.asStateFlow()
+    // SharedFlow(replay=0): new subscribers don't receive stale connection errors from before the game screen loaded
+    private val _errorMessages = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 10)
+    val errorMessages: SharedFlow<String> = _errorMessages.asSharedFlow()
 
     init {
         observeWebSocketMessages()
@@ -56,7 +60,7 @@ object GameApi {
                             .onSuccess { _cardsDealtUpdates.value = it }
                             .onFailure { it.printStackTrace() }
                     }
-                    type == "ERROR" -> _errorMessages.value = data
+                    type == "ERROR" -> _errorMessages.tryEmit(data)
                 }
             }
         }
@@ -65,7 +69,7 @@ object GameApi {
     private fun observeConnectionErrors() {
         scope.launch {
             WebSocketManager.errorMessages.collect { error ->
-                _errorMessages.value = error
+                _errorMessages.tryEmit(error)
             }
         }
     }

--- a/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
+++ b/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
@@ -29,10 +29,12 @@ object GameApi {
     private val _cardsDealtUpdates = MutableStateFlow<Map<String, List<TunnelCard>>?>(null)
     val cardsDealtUpdates: StateFlow<Map<String, List<TunnelCard>>?> = _cardsDealtUpdates.asStateFlow()
 
-    val errorMessages = WebSocketManager.errorMessages
+    private val _errorMessages = MutableStateFlow<String?>(null)
+    val errorMessages: StateFlow<String?> = _errorMessages.asStateFlow()
 
     init {
         observeWebSocketMessages()
+        observeConnectionErrors()
     }
 
     private fun observeWebSocketMessages() {
@@ -54,7 +56,16 @@ object GameApi {
                             .onSuccess { _cardsDealtUpdates.value = it }
                             .onFailure { it.printStackTrace() }
                     }
+                    type == "ERROR" -> _errorMessages.value = data
                 }
+            }
+        }
+    }
+
+    private fun observeConnectionErrors() {
+        scope.launch {
+            WebSocketManager.errorMessages.collect { error ->
+                _errorMessages.value = error
             }
         }
     }

--- a/app/app/src/main/java/com/aau/saboteur/network/game/GameJson.kt
+++ b/app/app/src/main/java/com/aau/saboteur/network/game/GameJson.kt
@@ -1,7 +1,9 @@
 package com.aau.saboteur.network.game
 
 import com.aau.saboteur.model.CreateGameRequest
+import com.aau.saboteur.model.DiscardCardRequest
 import com.aau.saboteur.model.GameState
+import com.aau.saboteur.model.PlayCardRequest
 import com.aau.saboteur.model.Player
 import com.aau.saboteur.model.TunnelCard
 import kotlinx.serialization.encodeToString
@@ -15,8 +17,9 @@ private val json = Json {
 }
 
 fun CreateGameRequest.toJson(): String = json.encodeToString(this)
+fun PlayCardRequest.toJson(): String = json.encodeToString(this)
+fun DiscardCardRequest.toJson(): String = json.encodeToString(this)
 
 fun String.toGameState(): GameState = json.decodeFromString(this)
-
 fun String.toPlayer(): Player = json.decodeFromString(this)
 fun String.toHands(): Map<String, List<TunnelCard>> = json.decodeFromString(this)

--- a/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardDrawableMapper.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardDrawableMapper.kt
@@ -41,6 +41,23 @@ fun TunnelCard.toDrawableName(): String = when (type) {
     }
 }
 
+// Returns the drawable name for the card's pre-rotation orientation so the
+// same asset is always used. The caller must apply Modifier.rotate(180f) when
+// card.isRotated is true to provide the visual transform.
+fun TunnelCard.toCanonicalDrawableName(): String =
+    if (!isRotated) toDrawableName()
+    else copy(
+        connections = connections.map { dir ->
+            when (dir) {
+                Direction.TOP    -> Direction.BOTTOM
+                Direction.BOTTOM -> Direction.TOP
+                Direction.LEFT   -> Direction.RIGHT
+                Direction.RIGHT  -> Direction.LEFT
+            }
+        }.toSet(),
+        isRotated = false
+    ).toDrawableName()
+
 fun TunnelCard.toContentDescription(): String = when (type) {
     CardType.START -> "Start card"
     CardType.GOAL -> if (isRevealed) "Revealed goal card" else "Hidden goal card"

--- a/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardDrawableMapper.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardDrawableMapper.kt
@@ -4,7 +4,7 @@ import com.aau.saboteur.model.CardType
 import com.aau.saboteur.model.Direction
 import com.aau.saboteur.model.TunnelCard
 
-internal fun TunnelCard.toDrawableName(): String = when (type) {
+fun TunnelCard.toDrawableName(): String = when (type) {
 
     CardType.CART_RED -> "cart_red"
     CardType.CART_GREEN -> "cart_green"
@@ -41,7 +41,7 @@ internal fun TunnelCard.toDrawableName(): String = when (type) {
     }
 }
 
-internal fun TunnelCard.toContentDescription(): String = when (type) {
+fun TunnelCard.toContentDescription(): String = when (type) {
     CardType.START -> "Start card"
     CardType.GOAL -> if (isRevealed) "Revealed goal card" else "Hidden goal card"
     CardType.PATH -> "Path card"

--- a/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardView.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardView.kt
@@ -37,7 +37,7 @@ fun TunnelCardView(
     card: TunnelCard,
     isSelected: Boolean = false,
     onCardSelected: (TunnelCard) -> Unit = {},
-    onRotationChanged: (TunnelCard, Boolean) -> Unit = {},
+    onRotationChanged: (TunnelCard, Boolean) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier
 ) {
     var isRotated by remember { mutableStateOf(card.isRotated) }

--- a/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardView.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardView.kt
@@ -4,20 +4,13 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.sp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -25,7 +18,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -35,10 +30,14 @@ import com.aau.saboteur.model.CardType
 import com.aau.saboteur.model.Direction
 import com.aau.saboteur.model.TunnelCard
 
+private val SelectedBorderColor = Color(0xFFF4D35E)
+
 @Composable
 fun TunnelCardView(
     card: TunnelCard,
-    onRotationChanged: (isRotated: Boolean) -> Unit = {},
+    isSelected: Boolean = false,
+    onCardSelected: (TunnelCard) -> Unit = {},
+    onRotationChanged: (TunnelCard, Boolean) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     var isRotated by remember { mutableStateOf(card.isRotated) }
@@ -53,43 +52,39 @@ fun TunnelCardView(
     val drawableName = card.toDrawableName()
     val resId = context.resources.getIdentifier(drawableName, "drawable", context.packageName)
 
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(4.dp),
+    Box(
+        contentAlignment = Alignment.Center,
         modifier = modifier
-    ) {
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .width(60.dp)
-                .height(90.dp)
-                .graphicsLayer { rotationZ = rotation }
-                .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(6.dp))
-        ) {
-            if (resId != 0) {
-                Image(
-                    painter = painterResource(id = resId),
-                    contentDescription = card.toContentDescription(),
-                    contentScale = ContentScale.FillBounds,
-                    modifier = Modifier.width(60.dp).height(90.dp)
-                )
-            } else {
-                Text(
-                    text = drawableName,
-                    style = MaterialTheme.typography.labelSmall
+            .width(60.dp)
+            .height(90.dp)
+            .graphicsLayer { rotationZ = rotation }
+            .border(
+                width = if (isSelected) 3.dp else 1.dp,
+                color = if (isSelected) SelectedBorderColor else MaterialTheme.colorScheme.outline,
+                shape = RoundedCornerShape(6.dp)
+            )
+            .pointerInput(card.id) {
+                detectTapGestures(
+                    onTap = { onCardSelected(card) },
+                    onDoubleTap = {
+                        isRotated = !isRotated
+                        onRotationChanged(card, isRotated)
+                    }
                 )
             }
-        }
-
-        Button(
-            onClick = {
-                isRotated = !isRotated
-                onRotationChanged(isRotated)
-            },
-            modifier = Modifier.width(60.dp),
-            contentPadding = PaddingValues(horizontal = 4.dp, vertical = 4.dp)
-        ) {
-            Text("Drehen", fontSize = 9.sp, maxLines = 1, textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth())
+    ) {
+        if (resId != 0) {
+            Image(
+                painter = painterResource(id = resId),
+                contentDescription = card.toContentDescription(),
+                contentScale = ContentScale.FillBounds,
+                modifier = Modifier.width(60.dp).height(90.dp)
+            )
+        } else {
+            Text(
+                text = drawableName,
+                style = MaterialTheme.typography.labelSmall
+            )
         }
     }
 }

--- a/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardView.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardView.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,6 +42,8 @@ fun TunnelCardView(
     modifier: Modifier = Modifier
 ) {
     var isRotated by remember { mutableStateOf(card.isRotated) }
+    val currentOnCardSelected by rememberUpdatedState(onCardSelected)
+    val currentOnRotationChanged by rememberUpdatedState(onRotationChanged)
 
     val rotation by animateFloatAsState(
         targetValue = if (isRotated) 180f else 0f,
@@ -65,10 +68,10 @@ fun TunnelCardView(
             )
             .pointerInput(card.id) {
                 detectTapGestures(
-                    onTap = { onCardSelected(card) },
+                    onTap = { currentOnCardSelected(card) },
                     onDoubleTap = {
                         isRotated = !isRotated
-                        onRotationChanged(card, isRotated)
+                        currentOnRotationChanged(card, isRotated)
                     }
                 )
             }

--- a/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardView.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/TunnelCardView.kt
@@ -60,7 +60,6 @@ fun TunnelCardView(
         modifier = modifier
             .width(60.dp)
             .height(90.dp)
-            .graphicsLayer { rotationZ = rotation }
             .border(
                 width = if (isSelected) 3.dp else 1.dp,
                 color = if (isSelected) SelectedBorderColor else MaterialTheme.colorScheme.outline,
@@ -81,12 +80,16 @@ fun TunnelCardView(
                 painter = painterResource(id = resId),
                 contentDescription = card.toContentDescription(),
                 contentScale = ContentScale.FillBounds,
-                modifier = Modifier.width(60.dp).height(90.dp)
+                modifier = Modifier
+                    .width(60.dp)
+                    .height(90.dp)
+                    .graphicsLayer { rotationZ = rotation }
             )
         } else {
             Text(
                 text = drawableName,
-                style = MaterialTheme.typography.labelSmall
+                style = MaterialTheme.typography.labelSmall,
+                modifier = Modifier.graphicsLayer { rotationZ = rotation }
             )
         }
     }

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
@@ -49,8 +49,9 @@ import com.aau.saboteur.model.CardType
 import com.aau.saboteur.model.Direction
 import com.aau.saboteur.model.PlacedTunnelCard
 import com.aau.saboteur.model.TunnelCard
+import androidx.compose.ui.draw.rotate
+import com.aau.saboteur.ui.toCanonicalDrawableName
 import com.aau.saboteur.ui.toContentDescription
-import com.aau.saboteur.ui.toDrawableName
 import kotlin.math.cos
 import kotlin.math.hypot
 import kotlin.math.sin
@@ -293,7 +294,7 @@ private fun BoardTile(
     onClick: () -> Unit = {},
 ) {
     val context = LocalContext.current
-    val drawableName = card?.toDrawableName()
+    val drawableName = card?.toCanonicalDrawableName()
     @Suppress("DiscouragedApi")
     val imageRes = drawableName?.let {
         context.resources.getIdentifier(it, "drawable", context.packageName)
@@ -322,6 +323,7 @@ private fun BoardTile(
                         contentDescription = card.toContentDescription(),
                         contentScale = ContentScale.FillBounds,
                         modifier = Modifier.fillMaxSize()
+                            .then(if (card.isRotated) Modifier.rotate(180f) else Modifier)
                     )
                 }
                 else -> ConnectionPattern(card = card)

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/BoardGrid.kt
@@ -321,11 +321,7 @@ private fun BoardTile(
                         painter = painterResource(id = imageRes),
                         contentDescription = card.toContentDescription(),
                         contentScale = ContentScale.FillBounds,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .graphicsLayer {
-                                rotationZ = if (card.isRotated) 180f else 0f
-                            }
+                        modifier = Modifier.fillMaxSize()
                     )
                 }
                 else -> ConnectionPattern(card = card)

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/PlayerHandRow.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/PlayerHandRow.kt
@@ -14,14 +14,22 @@ import com.aau.saboteur.ui.TunnelCardView
 @Composable
 fun PlayerHandRow(
     hand: List<TunnelCard>,
+    selectedCardId: String? = null,
+    onCardSelected: (TunnelCard) -> Unit = {},
+    onCardRotated: (TunnelCard, Boolean) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     LazyRow(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
     ) {
-        items(hand) { card ->
-            TunnelCardView(card = card)
+        items(hand, key = { it.id }) { card ->
+            TunnelCardView(
+                card = card,
+                isSelected = card.id == selectedCardId,
+                onCardSelected = onCardSelected,
+                onRotationChanged = onCardRotated
+            )
         }
     }
 }

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/PlayerHandRow.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/PlayerHandRow.kt
@@ -16,7 +16,7 @@ fun PlayerHandRow(
     hand: List<TunnelCard>,
     selectedCardId: String? = null,
     onCardSelected: (TunnelCard) -> Unit = {},
-    onCardRotated: (TunnelCard, Boolean) -> Unit = {},
+    onCardRotated: (TunnelCard, Boolean) -> Unit = { _, _ -> },
     modifier: Modifier = Modifier
 ) {
     LazyRow(

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -102,7 +102,7 @@ fun GameScreen(
 
             if (isMyTurn && sortedPlayers.isNotEmpty()) {
                 val hintText = when {
-                    uiState.selectedCard != null -> "Tap a board cell to place – or discard below"
+                    uiState.selectedCard != null -> "Tippe auf ein Feld zum Platzieren – oder verwirf die Karte unten."
                     showTurnHint -> "Your turn! Tap a card to select"
                     else -> null
                 }
@@ -190,7 +190,7 @@ fun GameScreen(
                             contentColor = MaterialTheme.colorScheme.onErrorContainer
                         )
                     ) {
-                        Text("Discard \"${uiState.selectedCard!!.type.name}\"")
+                        Text("Karte verwerfen")
                     }
                 }
 

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -2,6 +2,8 @@ package com.aau.saboteur.ui.screens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -32,6 +34,8 @@ fun GameScreen(
     val localPlayerId by lobbyViewModel.playerId.collectAsState()
     val sortedPlayers = uiState.gameState.players.sortedBy(PlayerTurn::turnOrder)
     val currentHand = uiState.localPlayerId?.let { uiState.hands?.get(it) }
+    val isMyTurn = uiState.localPlayerId != null &&
+            uiState.gameState.currentPlayerId == uiState.localPlayerId
 
     LaunchedEffect(localPlayerId) {
         viewModel.setLocalPlayerId(localPlayerId)
@@ -42,13 +46,17 @@ fun GameScreen(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
-        // Full screen board
         BoardGrid(
             placements = uiState.gameState.boardPlacements,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
+            onCellClick = { position ->
+                if (isMyTurn && uiState.selectedCard != null) {
+                    viewModel.onBoardCellClicked(position)
+                }
+            }
         )
 
-        // Top Overlay: Turn Order
+        // Top: turn order
         if (sortedPlayers.isNotEmpty()) {
             Box(
                 modifier = Modifier
@@ -71,7 +79,7 @@ fun GameScreen(
             }
         }
 
-        // Center Overlay: Status Messages (Errors, Loading)
+        // Center: status / errors
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
@@ -85,6 +93,22 @@ fun GameScreen(
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onBackground
                 )
+            }
+
+            if (isMyTurn && sortedPlayers.isNotEmpty()) {
+                Surface(
+                    color = Color(0xFF6E5524).copy(alpha = 0.9f),
+                    shape = MaterialTheme.shapes.medium,
+                    tonalElevation = 4.dp
+                ) {
+                    Text(
+                        text = if (uiState.selectedCard != null) "Tap a board cell to place – or discard below"
+                               else "Your turn! Tap a card to select",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.White,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
             }
 
             uiState.errorMessage?.let {
@@ -103,7 +127,7 @@ fun GameScreen(
             }
         }
 
-        // Bottom Overlay: Role and Hand
+        // Bottom: role card + optional discard + hand
         if (currentHand != null) {
             Column(
                 modifier = Modifier
@@ -113,23 +137,41 @@ fun GameScreen(
                         brush = Brush.verticalGradient(
                             colors = listOf(
                                 Color.Transparent,
-                                MaterialTheme.colorScheme.background.copy(alpha = 0.8f)
+                                MaterialTheme.colorScheme.background.copy(alpha = 0.85f)
                             )
                         )
                     )
                     .padding(bottom = 24.dp, top = 32.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 uiState.player?.role?.let { role ->
                     RoleCardView(
                         role = role,
                         compact = true,
-                        modifier = Modifier.padding(bottom = 12.dp)
+                        modifier = Modifier.padding(bottom = 4.dp)
                     )
                 }
 
+                if (isMyTurn && uiState.selectedCard != null) {
+                    Button(
+                        onClick = { viewModel.discardSelectedCard() },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer,
+                            contentColor = MaterialTheme.colorScheme.onErrorContainer
+                        )
+                    ) {
+                        Text("Discard \"${uiState.selectedCard!!.type.name}\"")
+                    }
+                }
+
                 PlayerHandRow(
-                    hand = currentHand
+                    hand = currentHand,
+                    selectedCardId = uiState.selectedCard?.id,
+                    onCardSelected = { card ->
+                        if (isMyTurn) viewModel.selectCard(card)
+                    },
+                    onCardRotated = { card, rotated -> viewModel.onCardRotated(card, rotated) }
                 )
             }
         }

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.aau.saboteur.R
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.aau.saboteur.model.PlayerTurn
 import com.aau.saboteur.ui.components.BoardGrid
@@ -103,7 +105,7 @@ fun GameScreen(
             if (isMyTurn && sortedPlayers.isNotEmpty()) {
                 val hintText = when {
                     uiState.selectedCard != null -> "Tippe auf ein Feld zum Platzieren – oder verwirf die Karte unten."
-                    showTurnHint -> "Your turn! Tap a card to select"
+                    showTurnHint -> stringResource(R.string.your_turn_hint)
                     else -> null
                 }
                 hintText?.let {
@@ -134,7 +136,7 @@ fun GameScreen(
         ) {
             if (sortedPlayers.isEmpty()) {
                 Text(
-                    text = if (uiState.isStartingGame) "Starting game..." else "Waiting for game state...",
+                    text = if (uiState.isStartingGame) stringResource(R.string.starting_game) else stringResource(R.string.waiting_for_game_state),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onBackground
                 )

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -11,6 +11,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
@@ -37,8 +41,20 @@ fun GameScreen(
     val isMyTurn = uiState.localPlayerId != null &&
             uiState.gameState.currentPlayerId == uiState.localPlayerId
 
+    var showTurnHint by remember { mutableStateOf(false) }
+
     LaunchedEffect(localPlayerId) {
         viewModel.setLocalPlayerId(localPlayerId)
+    }
+
+    LaunchedEffect(isMyTurn) {
+        if (isMyTurn) {
+            showTurnHint = true
+            delay(2000)
+            showTurnHint = false
+        } else {
+            showTurnHint = false
+        }
     }
 
     Box(
@@ -96,18 +112,25 @@ fun GameScreen(
             }
 
             if (isMyTurn && sortedPlayers.isNotEmpty()) {
-                Surface(
-                    color = Color(0xFF6E5524).copy(alpha = 0.9f),
-                    shape = MaterialTheme.shapes.medium,
-                    tonalElevation = 4.dp
-                ) {
-                    Text(
-                        text = if (uiState.selectedCard != null) "Tap a board cell to place – or discard below"
-                               else "Your turn! Tap a card to select",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = Color.White,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                    )
+                val hintText = if (uiState.selectedCard != null)
+                    "Tap a board cell to place – or discard below"
+                else if (showTurnHint)
+                    "Your turn! Tap a card to select"
+                else null
+
+                hintText?.let {
+                    Surface(
+                        color = Color(0xFF6E5524).copy(alpha = 0.9f),
+                        shape = MaterialTheme.shapes.medium,
+                        tonalElevation = 4.dp
+                    ) {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.White,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        )
+                    }
                 }
             }
 

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -72,30 +72,59 @@ fun GameScreen(
             }
         )
 
-        // Top: turn order
-        if (sortedPlayers.isNotEmpty()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(
-                        brush = Brush.verticalGradient(
-                            colors = listOf(
-                                MaterialTheme.colorScheme.background.copy(alpha = 0.8f),
-                                Color.Transparent
+        // Top: turn order + placement hint
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.TopCenter),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (sortedPlayers.isNotEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            brush = Brush.verticalGradient(
+                                colors = listOf(
+                                    MaterialTheme.colorScheme.background.copy(alpha = 0.8f),
+                                    Color.Transparent
+                                )
                             )
                         )
+                        .padding(top = 16.dp, bottom = 8.dp, start = 16.dp, end = 16.dp)
+                ) {
+                    PlayerTurnOrderRow(
+                        players = sortedPlayers,
+                        currentPlayerId = uiState.gameState.currentPlayerId
                     )
-                    .padding(top = 16.dp, bottom = 24.dp, start = 16.dp, end = 16.dp)
-                    .align(Alignment.TopCenter)
-            ) {
-                PlayerTurnOrderRow(
-                    players = sortedPlayers,
-                    currentPlayerId = uiState.gameState.currentPlayerId
-                )
+                }
+            }
+
+            if (isMyTurn && sortedPlayers.isNotEmpty()) {
+                val hintText = when {
+                    uiState.selectedCard != null -> "Tap a board cell to place – or discard below"
+                    showTurnHint -> "Your turn! Tap a card to select"
+                    else -> null
+                }
+                hintText?.let {
+                    Surface(
+                        color = Color(0xFF6E5524).copy(alpha = 0.9f),
+                        shape = MaterialTheme.shapes.medium,
+                        tonalElevation = 4.dp,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                    ) {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.White,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        )
+                    }
+                }
             }
         }
 
-        // Center: status / errors
+        // Center: waiting text + errors
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
@@ -109,29 +138,6 @@ fun GameScreen(
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onBackground
                 )
-            }
-
-            if (isMyTurn && sortedPlayers.isNotEmpty()) {
-                val hintText = if (uiState.selectedCard != null)
-                    "Tap a board cell to place – or discard below"
-                else if (showTurnHint)
-                    "Your turn! Tap a card to select"
-                else null
-
-                hintText?.let {
-                    Surface(
-                        color = Color(0xFF6E5524).copy(alpha = 0.9f),
-                        shape = MaterialTheme.shapes.medium,
-                        tonalElevation = 4.dp
-                    ) {
-                        Text(
-                            text = it,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = Color.White,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                        )
-                    }
-                }
             }
 
             uiState.errorMessage?.let {

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -40,7 +40,9 @@ class GameViewModel : ViewModel() {
                 _uiState.value = _uiState.value.copy(
                     gameState = newState,
                     isStartingGame = false,
-                    errorMessage = null
+                    errorMessage = null,
+                    selectedCard = null,
+                    selectedCardRotated = false
                 )
             }
         }
@@ -65,10 +67,12 @@ class GameViewModel : ViewModel() {
     private fun observeErrors() {
         viewModelScope.launch {
             GameApi.errorMessages.collect { message ->
-                _uiState.value = _uiState.value.copy(
-                    isStartingGame = false,
-                    errorMessage = message
-                )
+                if (message != null) {
+                    _uiState.value = _uiState.value.copy(
+                        isStartingGame = false,
+                        errorMessage = message
+                    )
+                }
             }
         }
     }
@@ -98,8 +102,8 @@ class GameViewModel : ViewModel() {
         val playerId = state.localPlayerId ?: return
         if (state.gameState.currentPlayerId != playerId) return
 
+        // Keep selection visible until server confirms; clear on GAME_STATE_UPDATE
         GameApi.playCard(playerId, card.id, position, state.selectedCardRotated)
-        _uiState.value = _uiState.value.copy(selectedCard = null, selectedCardRotated = false)
     }
 
     fun discardSelectedCard() {

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -3,6 +3,7 @@ package com.aau.saboteur.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.aau.saboteur.model.BoardPosition
+import com.aau.saboteur.model.CardType
 import com.aau.saboteur.model.GameState
 import com.aau.saboteur.model.Player
 import com.aau.saboteur.model.TunnelCard
@@ -116,6 +117,11 @@ class GameViewModel : ViewModel() {
         val card = state.selectedCard ?: return
         val playerId = state.localPlayerId ?: return
         if (state.gameState.currentPlayerId != playerId) return
+
+        if (card.type != CardType.PATH && card.type != CardType.DEAD_END) {
+            showError("Diese Karte kann hier nicht platziert werden.")
+            return
+        }
 
         GameApi.playCard(playerId, card.id, position, state.selectedCardRotated)
     }

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -2,6 +2,7 @@ package com.aau.saboteur.viewModels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.aau.saboteur.model.BoardPosition
 import com.aau.saboteur.model.GameState
 import com.aau.saboteur.model.Player
 import com.aau.saboteur.model.TunnelCard
@@ -17,7 +18,9 @@ data class GameUiState(
     val localPlayerId: String? = null,
     val player: Player? = null,
     val hands: Map<String, List<TunnelCard>>? = null,
-    val errorMessage: String? = null
+    val errorMessage: String? = null,
+    val selectedCard: TunnelCard? = null,
+    val selectedCardRotated: Boolean = false
 )
 
 class GameViewModel : ViewModel() {
@@ -46,9 +49,7 @@ class GameViewModel : ViewModel() {
     private fun observePlayerUpdates() {
         viewModelScope.launch {
             GameApi.playerUpdates.collect { updatedPlayer ->
-                _uiState.value = _uiState.value.copy(
-                    player = updatedPlayer
-                )
+                _uiState.value = _uiState.value.copy(player = updatedPlayer)
             }
         }
     }
@@ -74,5 +75,40 @@ class GameViewModel : ViewModel() {
 
     fun setLocalPlayerId(playerId: String?) {
         _uiState.value = _uiState.value.copy(localPlayerId = playerId)
+    }
+
+    fun selectCard(card: TunnelCard) {
+        val current = _uiState.value.selectedCard
+        if (current?.id == card.id) {
+            _uiState.value = _uiState.value.copy(selectedCard = null, selectedCardRotated = false)
+        } else {
+            _uiState.value = _uiState.value.copy(selectedCard = card, selectedCardRotated = false)
+        }
+    }
+
+    fun onCardRotated(card: TunnelCard, isRotated: Boolean) {
+        if (_uiState.value.selectedCard?.id == card.id) {
+            _uiState.value = _uiState.value.copy(selectedCardRotated = isRotated)
+        }
+    }
+
+    fun onBoardCellClicked(position: BoardPosition) {
+        val state = _uiState.value
+        val card = state.selectedCard ?: return
+        val playerId = state.localPlayerId ?: return
+        if (state.gameState.currentPlayerId != playerId) return
+
+        GameApi.playCard(playerId, card.id, position, state.selectedCardRotated)
+        _uiState.value = _uiState.value.copy(selectedCard = null, selectedCardRotated = false)
+    }
+
+    fun discardSelectedCard() {
+        val state = _uiState.value
+        val card = state.selectedCard ?: return
+        val playerId = state.localPlayerId ?: return
+        if (state.gameState.currentPlayerId != playerId) return
+
+        GameApi.discardCard(playerId, card.id)
+        _uiState.value = _uiState.value.copy(selectedCard = null, selectedCardRotated = false)
     }
 }

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -7,6 +7,8 @@ import com.aau.saboteur.model.GameState
 import com.aau.saboteur.model.Player
 import com.aau.saboteur.model.TunnelCard
 import com.aau.saboteur.network.game.GameApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,12 +22,15 @@ data class GameUiState(
     val hands: Map<String, List<TunnelCard>>? = null,
     val errorMessage: String? = null,
     val selectedCard: TunnelCard? = null,
-    val selectedCardRotated: Boolean = false
+    val selectedCardRotated: Boolean = false,
+    val cardRotations: Map<String, Boolean> = emptyMap()
 )
 
 class GameViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(GameUiState())
     val uiState: StateFlow<GameUiState> = _uiState.asStateFlow()
+
+    private var errorClearJob: Job? = null
 
     init {
         observeGameStateUpdates()
@@ -59,7 +64,7 @@ class GameViewModel : ViewModel() {
     private fun observeCardsDealt() {
         viewModelScope.launch {
             GameApi.cardsDealtUpdates.collect { hands ->
-                _uiState.value = _uiState.value.copy(hands = hands)
+                _uiState.value = _uiState.value.copy(hands = hands, cardRotations = emptyMap())
             }
         }
     }
@@ -67,13 +72,17 @@ class GameViewModel : ViewModel() {
     private fun observeErrors() {
         viewModelScope.launch {
             GameApi.errorMessages.collect { message ->
-                if (message != null) {
-                    _uiState.value = _uiState.value.copy(
-                        isStartingGame = false,
-                        errorMessage = message
-                    )
-                }
+                showError(message)
             }
+        }
+    }
+
+    private fun showError(message: String) {
+        errorClearJob?.cancel()
+        _uiState.value = _uiState.value.copy(isStartingGame = false, errorMessage = message)
+        errorClearJob = viewModelScope.launch {
+            delay(2000)
+            _uiState.value = _uiState.value.copy(errorMessage = null)
         }
     }
 
@@ -86,14 +95,20 @@ class GameViewModel : ViewModel() {
         if (current?.id == card.id) {
             _uiState.value = _uiState.value.copy(selectedCard = null, selectedCardRotated = false)
         } else {
-            _uiState.value = _uiState.value.copy(selectedCard = card, selectedCardRotated = false)
+            // Preserve any rotation the user already applied before selecting
+            val isRotated = _uiState.value.cardRotations[card.id] ?: card.isRotated
+            _uiState.value = _uiState.value.copy(selectedCard = card, selectedCardRotated = isRotated)
         }
     }
 
     fun onCardRotated(card: TunnelCard, isRotated: Boolean) {
-        if (_uiState.value.selectedCard?.id == card.id) {
-            _uiState.value = _uiState.value.copy(selectedCardRotated = isRotated)
-        }
+        val newRotations = _uiState.value.cardRotations + (card.id to isRotated)
+        val newSelectedCardRotated = if (_uiState.value.selectedCard?.id == card.id) isRotated
+                                     else _uiState.value.selectedCardRotated
+        _uiState.value = _uiState.value.copy(
+            cardRotations = newRotations,
+            selectedCardRotated = newSelectedCardRotated
+        )
     }
 
     fun onBoardCellClicked(position: BoardPosition) {
@@ -102,7 +117,6 @@ class GameViewModel : ViewModel() {
         val playerId = state.localPlayerId ?: return
         if (state.gameState.currentPlayerId != playerId) return
 
-        // Keep selection visible until server confirms; clear on GAME_STATE_UPDATE
         GameApi.playCard(playerId, card.id, position, state.selectedCardRotated)
     }
 

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">SE2Game</string>
+    <string name="your_turn_hint">Du bist dran! Wähle eine Karte aus.</string>
+    <string name="starting_game">Spiel wird gestartet…</string>
+    <string name="waiting_for_game_state">Warte auf Spielzustand…</string>
 </resources>

--- a/server/src/main/kotlin/com/aau/server/game/GameBoard.kt
+++ b/server/src/main/kotlin/com/aau/server/game/GameBoard.kt
@@ -23,7 +23,7 @@ class GameBoard {
     // cell must be empty, at least one neighbour must exist,
     // XOR rule: invalid only if exactly one shared edge side connects (open tunnel);
     // both-connect and both-wall are valid,
-    // and the cell must be reachable from the start card via PATH cards.
+    // and the cell must be reachable from the start card via PATH, START, and revealed GOAL cards.
     fun canPlaceCard(x: Int, y: Int, card: TunnelCard): Boolean {
         val pos = Pair(x, y)
         if (grid.containsKey(pos)) return false

--- a/server/src/main/kotlin/com/aau/server/game/GameBoard.kt
+++ b/server/src/main/kotlin/com/aau/server/game/GameBoard.kt
@@ -1,5 +1,6 @@
 package com.aau.server.game
 
+import com.aau.saboteur.model.CardType
 import com.aau.saboteur.model.Direction
 import com.aau.saboteur.model.TunnelCard
 import com.aau.server.game.CardDeck
@@ -20,33 +21,77 @@ class GameBoard {
 
     // Returns true if the card may be placed at (x,y):
     // cell must be empty, at least one neighbour must exist,
-    // and all shared edges with neighbours must have matching connections.
+    // XOR rule: invalid only if exactly one shared edge side connects (open tunnel);
+    // both-connect and both-wall are valid,
+    // and the cell must be reachable from the start card via PATH cards.
     fun canPlaceCard(x: Int, y: Int, card: TunnelCard): Boolean {
-        if (grid.containsKey(Pair(x, y))) return false
+        val pos = Pair(x, y)
+        if (grid.containsKey(pos)) return false
 
         val neighbors = mapOf(
-            Direction.TOP to grid[Pair(x, y - 1)],
-            Direction.RIGHT to grid[Pair(x + 1, y)],
+            Direction.TOP    to grid[Pair(x, y - 1)],
+            Direction.RIGHT  to grid[Pair(x + 1, y)],
             Direction.BOTTOM to grid[Pair(x, y + 1)],
-            Direction.LEFT to grid[Pair(x - 1, y)]
+            Direction.LEFT   to grid[Pair(x - 1, y)]
         )
 
-        val hasNeighbor = neighbors.values.any { it != null }
-        if (!hasNeighbor) return false
+        if (neighbors.values.none { it != null }) return false
 
-        return neighbors.all { (direction, neighbor) ->
+        // XOR rule: invalid if exactly one side connects (open tunnel). Both connect or both wall → valid.
+        val adjacencyOk = neighbors.all { (direction, neighbor) ->
             if (neighbor == null) true
             else {
-                val oppositeDir = when (direction) {
-                    Direction.TOP    -> Direction.BOTTOM
-                    Direction.BOTTOM -> Direction.TOP
-                    Direction.LEFT   -> Direction.RIGHT
-                    Direction.RIGHT  -> Direction.LEFT
-                }
                 val cardConnects = direction in card.connections
-                val neighborConnects = oppositeDir in neighbor.connections
+                val neighborConnects = opposite(direction) in neighbor.connections
                 cardConnects == neighborConnects
             }
         }
+        if (!adjacencyOk) return false
+
+        return isReachableFromStart(x, y)
+    }
+
+    // BFS from startPosition through START and PATH cards; returns true if (x,y) is
+    // adjacent to at least one reachable card that connects toward it.
+    private fun isReachableFromStart(x: Int, y: Int): Boolean {
+        val visited = mutableSetOf<Pair<Int, Int>>()
+        val queue = ArrayDeque<Pair<Int, Int>>()
+        queue.add(startPosition)
+        visited.add(startPosition)
+
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            val currentCard = grid[current] ?: continue
+            for (dir in Direction.values()) {
+                val neighborPos = gridNeighbor(current, dir)
+                if (neighborPos in visited) continue
+                val neighborCard = grid[neighborPos] ?: continue
+                if (neighborCard.type != CardType.PATH && neighborCard.type != CardType.START) continue
+                if (dir in currentCard.connections && opposite(dir) in neighborCard.connections) {
+                    visited.add(neighborPos)
+                    queue.add(neighborPos)
+                }
+            }
+        }
+
+        val target = Pair(x, y)
+        return Direction.values().any { dir ->
+            val neighborPos = gridNeighbor(target, dir)
+            neighborPos in visited && opposite(dir) in (grid[neighborPos]?.connections ?: emptySet())
+        }
+    }
+
+    private fun gridNeighbor(pos: Pair<Int, Int>, dir: Direction): Pair<Int, Int> = when (dir) {
+        Direction.TOP    -> Pair(pos.first, pos.second - 1)
+        Direction.BOTTOM -> Pair(pos.first, pos.second + 1)
+        Direction.LEFT   -> Pair(pos.first - 1, pos.second)
+        Direction.RIGHT  -> Pair(pos.first + 1, pos.second)
+    }
+
+    private fun opposite(dir: Direction): Direction = when (dir) {
+        Direction.TOP    -> Direction.BOTTOM
+        Direction.BOTTOM -> Direction.TOP
+        Direction.LEFT   -> Direction.RIGHT
+        Direction.RIGHT  -> Direction.LEFT
     }
 }

--- a/server/src/main/kotlin/com/aau/server/game/GameBoard.kt
+++ b/server/src/main/kotlin/com/aau/server/game/GameBoard.kt
@@ -51,7 +51,7 @@ class GameBoard {
         return isReachableFromStart(x, y)
     }
 
-    // BFS from startPosition through START and PATH cards; returns true if (x,y) is
+    // BFS from startPosition through START, PATH, and revealed GOAL cards; returns true if (x,y) is
     // adjacent to at least one reachable card that connects toward it.
     private fun isReachableFromStart(x: Int, y: Int): Boolean {
         val visited = mutableSetOf<Pair<Int, Int>>()
@@ -66,7 +66,10 @@ class GameBoard {
                 val neighborPos = gridNeighbor(current, dir)
                 if (neighborPos in visited) continue
                 val neighborCard = grid[neighborPos] ?: continue
-                if (neighborCard.type != CardType.PATH && neighborCard.type != CardType.START) continue
+                val traversable = neighborCard.type == CardType.PATH ||
+                    neighborCard.type == CardType.START ||
+                    (neighborCard.type == CardType.GOAL && neighborCard.isRevealed)
+                if (!traversable) continue
                 if (dir in currentCard.connections && opposite(dir) in neighborCard.connections) {
                     visited.add(neighborPos)
                     queue.add(neighborPos)

--- a/server/src/main/kotlin/com/aau/server/model/TurnResult.kt
+++ b/server/src/main/kotlin/com/aau/server/model/TurnResult.kt
@@ -1,0 +1,9 @@
+package com.aau.server.model
+
+import com.aau.saboteur.model.GameState
+import com.aau.saboteur.model.TunnelCard
+
+data class TurnResult(
+    val updatedGameState: GameState,
+    val updatedHands: Map<String, List<TunnelCard>>
+)

--- a/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
+++ b/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
@@ -156,7 +156,8 @@ class TurnManager {
         return isReachableFromStart(position, placements)
     }
 
-    // BFS from the START card through PATH and START cards only (dead-ends are not traversable).
+    // BFS from the START card. PATH, START, and revealed GOAL cards are traversable nodes;
+    // unrevealed goals and dead-ends are not.
     // Returns true if any directly adjacent reachable card connects toward the target position.
     private fun isReachableFromStart(
         position: BoardPosition,
@@ -177,7 +178,10 @@ class TurnManager {
                 val neighborPos = boardNeighbor(current, dir)
                 if (neighborPos in visited) continue
                 val neighborCard = grid[neighborPos]?.card ?: continue
-                if (neighborCard.type != CardType.PATH && neighborCard.type != CardType.START) continue
+                val traversable = neighborCard.type == CardType.PATH ||
+                    neighborCard.type == CardType.START ||
+                    (neighborCard.type == CardType.GOAL && neighborCard.isRevealed)
+                if (!traversable) continue
                 if (dir in currentCard.connections && opposite(dir) in neighborCard.connections) {
                     visited.add(neighborPos)
                     queue.add(neighborPos)

--- a/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
+++ b/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
@@ -1,6 +1,7 @@
 package com.aau.server.service
 
 import com.aau.saboteur.model.BoardPosition
+import com.aau.saboteur.model.CardType
 import com.aau.saboteur.model.Direction
 import com.aau.saboteur.model.GameState
 import com.aau.saboteur.model.PlacedTunnelCard
@@ -49,10 +50,14 @@ class TurnManager {
         val card = playerHand.find { it.id == cardId }
             ?: throw IllegalArgumentException("Card $cardId not in hand of player $playerId")
 
+        require(card.type == CardType.PATH || card.type == CardType.DEAD_END) {
+            "Diese Karte kann hier nicht platziert werden."
+        }
+
         val effectiveCard = if (isRotated) card.flipConnections() else card
 
         require(canPlaceOnBoard(position, effectiveCard, state.boardPlacements)) {
-            "Card $cardId cannot be placed at position $position"
+            "Diese Karte kann hier nicht platziert werden."
         }
 
         playerHand.remove(card)

--- a/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
+++ b/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
@@ -6,6 +6,7 @@ import com.aau.saboteur.model.Direction
 import com.aau.saboteur.model.GameState
 import com.aau.saboteur.model.PlacedTunnelCard
 import com.aau.saboteur.model.TunnelCard
+import com.aau.server.game.*
 import com.aau.server.model.CardDistributionResult
 import com.aau.server.model.TurnResult
 import org.springframework.stereotype.Service
@@ -42,19 +43,19 @@ class TurnManager {
         val state = gameState.get()
 
         require(state.currentPlayerId == playerId) {
-            "It is not player $playerId's turn"
+            "Du bist nicht am Zug."
         }
 
         val playerHand = hands[playerId]
-            ?: throw IllegalArgumentException("Player $playerId not found")
+            ?: throw IllegalArgumentException("Spieler $playerId nicht gefunden.")
         val card = playerHand.find { it.id == cardId }
-            ?: throw IllegalArgumentException("Card $cardId not in hand of player $playerId")
+            ?: throw IllegalArgumentException("Karte $cardId nicht in der Hand von Spieler $playerId.")
 
         require(card.type == CardType.PATH || card.type == CardType.DEAD_END) {
             "Diese Karte kann hier nicht platziert werden."
         }
 
-        val effectiveCard = if (isRotated) card.flipConnections() else card
+        val effectiveCard = if (isRotated) card.rotated180() else card
 
         require(canPlaceOnBoard(position, effectiveCard, state.boardPlacements)) {
             "Diese Karte kann hier nicht platziert werden."
@@ -85,14 +86,14 @@ class TurnManager {
         val state = gameState.get()
 
         require(state.currentPlayerId == playerId) {
-            "It is not player $playerId's turn"
+            "Du bist nicht am Zug."
         }
 
         val playerHand = hands[playerId]
-            ?: throw IllegalArgumentException("Player $playerId not found")
+            ?: throw IllegalArgumentException("Spieler $playerId nicht gefunden.")
 
         require(playerHand.any { it.id == cardId }) {
-            "Card $cardId not in hand of player $playerId"
+            "Karte $cardId nicht in der Hand von Spieler $playerId."
         }
 
         playerHand.removeIf { it.id == cardId }
@@ -123,6 +124,9 @@ class TurnManager {
         return sorted[(idx + 1) % sorted.size].playerId
     }
 
+    private fun buildGrid(placements: List<PlacedTunnelCard>): Map<BoardPosition, PlacedTunnelCard> =
+        placements.associateBy { it.position }
+
     private fun canPlaceOnBoard(
         position: BoardPosition,
         card: TunnelCard,
@@ -130,7 +134,7 @@ class TurnManager {
     ): Boolean {
         if (placements.any { it.position == position }) return false
 
-        val grid = placements.associateBy { it.position }
+        val grid = buildGrid(placements)
         val neighbors = mapOf(
             Direction.TOP    to grid[BoardPosition(position.row - 1, position.column)],
             Direction.BOTTOM to grid[BoardPosition(position.row + 1, position.column)],
@@ -141,9 +145,10 @@ class TurnManager {
         if (neighbors.values.none { it != null }) return false
 
         // XOR rule: invalid if exactly one side connects (open tunnel). Both connect or both wall → valid.
-        // Unrevealed goal cards are exempt: they will be revealed and auto-rotated after placement.
         val adjacencyOk = neighbors.all { (dir, neighbor) ->
             if (neighbor == null) true
+            // Unrevealed goal cards are exempt from adjacency matching here —
+            // their connections will be corrected by auto-rotation at reveal time.
             else if (neighbor.card.type == CardType.GOAL && !neighbor.card.isRevealed) true
             else {
                 val cardConnects = dir in card.connections
@@ -153,7 +158,7 @@ class TurnManager {
         }
         if (!adjacencyOk) return false
 
-        return isReachableFromStart(position, placements)
+        return isReachableFromStart(position, grid)
     }
 
     // BFS from the START card. PATH, START, and revealed GOAL cards are traversable nodes;
@@ -161,9 +166,8 @@ class TurnManager {
     // Returns true if any directly adjacent reachable card connects toward the target position.
     private fun isReachableFromStart(
         position: BoardPosition,
-        placements: List<PlacedTunnelCard>
+        grid: Map<BoardPosition, PlacedTunnelCard>
     ): Boolean {
-        val grid = placements.associateBy { it.position }
         val startPos = grid.entries.find { it.value.card.type == CardType.START }?.key ?: return false
 
         val visited = mutableSetOf<BoardPosition>()
@@ -189,6 +193,9 @@ class TurnManager {
             }
         }
 
+        // The XOR adjacency rule (checked before this call) guarantees that if a visited neighbor
+        // connects toward `position` (neighborConnects=true), the card being placed also connects
+        // back toward that neighbor (cardConnects=true). No need to re-check the card's connections here.
         return Direction.values().any { dir ->
             val neighborPos = boardNeighbor(position, dir)
             neighborPos in visited && opposite(dir) in (grid[neighborPos]?.card?.connections ?: emptySet())
@@ -207,6 +214,13 @@ class TurnManager {
         placedCard: TunnelCard,
         placements: List<PlacedTunnelCard>
     ): List<PlacedTunnelCard> {
+        // Build a mutable lookup for O(1) updates during the reveal scan.
+        // Known design gap: if a goal card already has a PATH neighbor on side A (placed under the
+        // unrevealed-goal exemption) and is then auto-rotated 180° on reveal from side B, the
+        // previously-placed neighbor's connection on side A may no longer match the rotated goal.
+        // By game rules, goal cards are placed far from the start and reachable from only one
+        // direction at reveal time, so this conflict cannot occur in a normal game. The exemption
+        // is therefore intentional and any mismatch would indicate an invalid board state.
         val grid = placements.associateBy { it.position }.toMutableMap()
         for (dir in Direction.values()) {
             val neighborPos = boardNeighbor(placedPosition, dir)
@@ -222,20 +236,11 @@ class TurnManager {
             ) else neighborCard.copy(isRevealed = true)
             grid[neighborPos] = neighborPlacement.copy(card = revealedCard)
         }
-        return grid.values.toList()
+        // Preserve original list order by mapping through the updated grid rather than
+        // relying on LinkedHashMap insertion-order from grid.values.
+        // grid was built from placements via associateBy, so every position is guaranteed present.
+        return placements.map { grid.getValue(it.position) }
     }
-
-    private fun TunnelCard.flipConnections(): TunnelCard = copy(
-        connections = connections.map {
-            when (it) {
-                Direction.TOP    -> Direction.BOTTOM
-                Direction.BOTTOM -> Direction.TOP
-                Direction.LEFT   -> Direction.RIGHT
-                Direction.RIGHT  -> Direction.LEFT
-            }
-        }.toSet(),
-        isRotated = true
-    )
 
     private fun opposite(direction: Direction): Direction = when (direction) {
         Direction.TOP    -> Direction.BOTTOM

--- a/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
+++ b/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
@@ -63,7 +63,12 @@ class TurnManager {
         playerHand.remove(card)
         drawCardForPlayer(playerId)
 
-        val newPlacements = state.boardPlacements + PlacedTunnelCard(position, effectiveCard)
+        val placementsWithCard = state.boardPlacements + PlacedTunnelCard(position, effectiveCard)
+        val newPlacements = if (effectiveCard.type == CardType.PATH) {
+            revealGoalCards(position, effectiveCard, placementsWithCard)
+        } else {
+            placementsWithCard
+        }
         val newState = state.copy(
             boardPlacements = newPlacements,
             currentPlayerId = nextPlayerId(state)
@@ -136,8 +141,10 @@ class TurnManager {
         if (neighbors.values.none { it != null }) return false
 
         // XOR rule: invalid if exactly one side connects (open tunnel). Both connect or both wall → valid.
+        // Unrevealed goal cards are exempt: they will be revealed and auto-rotated after placement.
         val adjacencyOk = neighbors.all { (dir, neighbor) ->
             if (neighbor == null) true
+            else if (neighbor.card.type == CardType.GOAL && !neighbor.card.isRevealed) true
             else {
                 val cardConnects = dir in card.connections
                 val neighborConnects = opposite(dir) in neighbor.card.connections
@@ -189,6 +196,29 @@ class TurnManager {
         Direction.BOTTOM -> BoardPosition(pos.row + 1, pos.column)
         Direction.LEFT   -> BoardPosition(pos.row, pos.column - 1)
         Direction.RIGHT  -> BoardPosition(pos.row, pos.column + 1)
+    }
+
+    private fun revealGoalCards(
+        placedPosition: BoardPosition,
+        placedCard: TunnelCard,
+        placements: List<PlacedTunnelCard>
+    ): List<PlacedTunnelCard> {
+        val grid = placements.associateBy { it.position }.toMutableMap()
+        for (dir in Direction.values()) {
+            val neighborPos = boardNeighbor(placedPosition, dir)
+            val neighborPlacement = grid[neighborPos] ?: continue
+            val neighborCard = neighborPlacement.card
+            if (neighborCard.type != CardType.GOAL || neighborCard.isRevealed) continue
+            if (dir !in placedCard.connections) continue
+            val goalConnects = opposite(dir) in neighborCard.connections
+            val revealedCard = if (!goalConnects) neighborCard.copy(
+                connections = neighborCard.connections.map { opposite(it) }.toSet(),
+                isRotated = true,
+                isRevealed = true
+            ) else neighborCard.copy(isRevealed = true)
+            grid[neighborPos] = neighborPlacement.copy(card = revealedCard)
+        }
+        return grid.values.toList()
     }
 
     private fun TunnelCard.flipConnections(): TunnelCard = copy(

--- a/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
+++ b/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
@@ -135,15 +135,60 @@ class TurnManager {
 
         if (neighbors.values.none { it != null }) return false
 
-        return neighbors.all { (dir, neighbor) ->
+        // XOR rule: invalid if exactly one side connects (open tunnel). Both connect or both wall → valid.
+        val adjacencyOk = neighbors.all { (dir, neighbor) ->
             if (neighbor == null) true
             else {
-                val opposite = opposite(dir)
                 val cardConnects = dir in card.connections
-                val neighborConnects = opposite in neighbor.card.connections
+                val neighborConnects = opposite(dir) in neighbor.card.connections
                 cardConnects == neighborConnects
             }
         }
+        if (!adjacencyOk) return false
+
+        return isReachableFromStart(position, placements)
+    }
+
+    // BFS from the START card through PATH and START cards only (dead-ends are not traversable).
+    // Returns true if any directly adjacent reachable card connects toward the target position.
+    private fun isReachableFromStart(
+        position: BoardPosition,
+        placements: List<PlacedTunnelCard>
+    ): Boolean {
+        val grid = placements.associateBy { it.position }
+        val startPos = grid.entries.find { it.value.card.type == CardType.START }?.key ?: return false
+
+        val visited = mutableSetOf<BoardPosition>()
+        val queue = ArrayDeque<BoardPosition>()
+        queue.add(startPos)
+        visited.add(startPos)
+
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            val currentCard = grid[current]?.card ?: continue
+            for (dir in Direction.values()) {
+                val neighborPos = boardNeighbor(current, dir)
+                if (neighborPos in visited) continue
+                val neighborCard = grid[neighborPos]?.card ?: continue
+                if (neighborCard.type != CardType.PATH && neighborCard.type != CardType.START) continue
+                if (dir in currentCard.connections && opposite(dir) in neighborCard.connections) {
+                    visited.add(neighborPos)
+                    queue.add(neighborPos)
+                }
+            }
+        }
+
+        return Direction.values().any { dir ->
+            val neighborPos = boardNeighbor(position, dir)
+            neighborPos in visited && opposite(dir) in (grid[neighborPos]?.card?.connections ?: emptySet())
+        }
+    }
+
+    private fun boardNeighbor(pos: BoardPosition, dir: Direction): BoardPosition = when (dir) {
+        Direction.TOP    -> BoardPosition(pos.row - 1, pos.column)
+        Direction.BOTTOM -> BoardPosition(pos.row + 1, pos.column)
+        Direction.LEFT   -> BoardPosition(pos.row, pos.column - 1)
+        Direction.RIGHT  -> BoardPosition(pos.row, pos.column + 1)
     }
 
     private fun TunnelCard.flipConnections(): TunnelCard = copy(

--- a/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
+++ b/server/src/main/kotlin/com/aau/server/service/TurnManager.kt
@@ -1,0 +1,162 @@
+package com.aau.server.service
+
+import com.aau.saboteur.model.BoardPosition
+import com.aau.saboteur.model.Direction
+import com.aau.saboteur.model.GameState
+import com.aau.saboteur.model.PlacedTunnelCard
+import com.aau.saboteur.model.TunnelCard
+import com.aau.server.model.CardDistributionResult
+import com.aau.server.model.TurnResult
+import org.springframework.stereotype.Service
+import java.util.concurrent.atomic.AtomicReference
+
+@Service
+class TurnManager {
+
+    private val lock = Any()
+
+    // Guarded by lock
+    private var hands: Map<String, MutableList<TunnelCard>> = emptyMap()
+    private var drawPile: MutableList<TunnelCard> = mutableListOf()
+
+    private val gameState = AtomicReference(GameState())
+
+    fun initializeGame(distribution: CardDistributionResult, initialGameState: GameState) {
+        synchronized(lock) {
+            hands = distribution.hands.mapValues { (_, cards) -> cards.toMutableList() }
+            drawPile = distribution.drawPile.toMutableList()
+        }
+        gameState.set(initialGameState)
+    }
+
+    /**
+     * Places a card from the player's hand onto the board, then draws a replacement and advances the turn.
+     */
+    fun playCard(
+        playerId: String,
+        cardId: String,
+        position: BoardPosition,
+        isRotated: Boolean
+    ): TurnResult = synchronized(lock) {
+        val state = gameState.get()
+
+        require(state.currentPlayerId == playerId) {
+            "It is not player $playerId's turn"
+        }
+
+        val playerHand = hands[playerId]
+            ?: throw IllegalArgumentException("Player $playerId not found")
+        val card = playerHand.find { it.id == cardId }
+            ?: throw IllegalArgumentException("Card $cardId not in hand of player $playerId")
+
+        val effectiveCard = if (isRotated) card.flipConnections() else card
+
+        require(canPlaceOnBoard(position, effectiveCard, state.boardPlacements)) {
+            "Card $cardId cannot be placed at position $position"
+        }
+
+        playerHand.remove(card)
+        drawCardForPlayer(playerId)
+
+        val newPlacements = state.boardPlacements + PlacedTunnelCard(position, effectiveCard)
+        val newState = state.copy(
+            boardPlacements = newPlacements,
+            currentPlayerId = nextPlayerId(state)
+        )
+        gameState.set(newState)
+
+        TurnResult(newState, hands.mapValues { it.value.toList() })
+    }
+
+    /**
+     * Discards a card without placing it, draws a replacement and advances the turn.
+     */
+    fun discardCard(playerId: String, cardId: String): TurnResult = synchronized(lock) {
+        val state = gameState.get()
+
+        require(state.currentPlayerId == playerId) {
+            "It is not player $playerId's turn"
+        }
+
+        val playerHand = hands[playerId]
+            ?: throw IllegalArgumentException("Player $playerId not found")
+
+        require(playerHand.any { it.id == cardId }) {
+            "Card $cardId not in hand of player $playerId"
+        }
+
+        playerHand.removeIf { it.id == cardId }
+        drawCardForPlayer(playerId)
+
+        val newState = state.copy(currentPlayerId = nextPlayerId(state))
+        gameState.set(newState)
+
+        TurnResult(newState, hands.mapValues { it.value.toList() })
+    }
+
+    fun getGameState(): GameState = gameState.get()
+
+    fun getHands(): Map<String, List<TunnelCard>> = synchronized(lock) {
+        hands.mapValues { it.value.toList() }
+    }
+
+    // Must be called while holding lock
+    private fun drawCardForPlayer(playerId: String) {
+        if (drawPile.isEmpty()) return
+        hands[playerId]?.add(drawPile.removeFirst())
+    }
+
+    private fun nextPlayerId(state: GameState): String? {
+        val sorted = state.players.sortedBy { it.turnOrder }
+        val idx = sorted.indexOfFirst { it.playerId == state.currentPlayerId }
+        if (idx == -1) return sorted.firstOrNull()?.playerId
+        return sorted[(idx + 1) % sorted.size].playerId
+    }
+
+    private fun canPlaceOnBoard(
+        position: BoardPosition,
+        card: TunnelCard,
+        placements: List<PlacedTunnelCard>
+    ): Boolean {
+        if (placements.any { it.position == position }) return false
+
+        val grid = placements.associateBy { it.position }
+        val neighbors = mapOf(
+            Direction.TOP    to grid[BoardPosition(position.row - 1, position.column)],
+            Direction.BOTTOM to grid[BoardPosition(position.row + 1, position.column)],
+            Direction.LEFT   to grid[BoardPosition(position.row, position.column - 1)],
+            Direction.RIGHT  to grid[BoardPosition(position.row, position.column + 1)]
+        )
+
+        if (neighbors.values.none { it != null }) return false
+
+        return neighbors.all { (dir, neighbor) ->
+            if (neighbor == null) true
+            else {
+                val opposite = opposite(dir)
+                val cardConnects = dir in card.connections
+                val neighborConnects = opposite in neighbor.card.connections
+                cardConnects == neighborConnects
+            }
+        }
+    }
+
+    private fun TunnelCard.flipConnections(): TunnelCard = copy(
+        connections = connections.map {
+            when (it) {
+                Direction.TOP    -> Direction.BOTTOM
+                Direction.BOTTOM -> Direction.TOP
+                Direction.LEFT   -> Direction.RIGHT
+                Direction.RIGHT  -> Direction.LEFT
+            }
+        }.toSet(),
+        isRotated = true
+    )
+
+    private fun opposite(direction: Direction): Direction = when (direction) {
+        Direction.TOP    -> Direction.BOTTOM
+        Direction.BOTTOM -> Direction.TOP
+        Direction.LEFT   -> Direction.RIGHT
+        Direction.RIGHT  -> Direction.LEFT
+    }
+}

--- a/server/src/main/kotlin/com/aau/server/websocket/WebSocketHandler.kt
+++ b/server/src/main/kotlin/com/aau/server/websocket/WebSocketHandler.kt
@@ -76,6 +76,7 @@ class WebSocketHandler(
                         val sessionPlayerId = messagingService.getPlayerIdForSession(session.id)
                             ?: throw IllegalArgumentException("Session is not linked to a player")
 
+                        // Guard against a client sending another player's ID in the payload.
                         require(sessionPlayerId == request.playerId) {
                             "Player ID mismatch: session belongs to $sessionPlayerId"
                         }
@@ -99,6 +100,7 @@ class WebSocketHandler(
                         val sessionPlayerId = messagingService.getPlayerIdForSession(session.id)
                             ?: throw IllegalArgumentException("Session is not linked to a player")
 
+                        // Guard against a client sending another player's ID in the payload.
                         require(sessionPlayerId == request.playerId) {
                             "Player ID mismatch: session belongs to $sessionPlayerId"
                         }

--- a/server/src/main/kotlin/com/aau/server/websocket/WebSocketHandler.kt
+++ b/server/src/main/kotlin/com/aau/server/websocket/WebSocketHandler.kt
@@ -4,6 +4,7 @@ import com.aau.saboteur.model.*
 import com.aau.server.service.GameService
 import com.aau.server.service.LobbyService
 import com.aau.server.service.MessagingService
+import com.aau.server.service.TurnManager
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import org.slf4j.LoggerFactory
@@ -18,7 +19,8 @@ class WebSocketHandler(
     private val objectMapper: ObjectMapper,
     private val gameService: GameService,
     private val messagingService: MessagingService,
-    private val lobbyService: LobbyService
+    private val lobbyService: LobbyService,
+    private val turnManager: TurnManager
 ) : TextWebSocketHandler() {
 
     private val logger = LoggerFactory.getLogger(WebSocketHandler::class.java)
@@ -53,6 +55,8 @@ class WebSocketHandler(
                         }
 
                         val result = gameService.startGame(request.players)
+                        turnManager.initializeGame(result.cardDistribution, result.gameState)
+
                         val startedLobby = lobbyService.markGameStarted(lobbyCode)
 
                         messagingService.broadcastToLobby(lobbyCode, "LOBBY_STATE_UPDATE", startedLobby)
@@ -62,6 +66,50 @@ class WebSocketHandler(
                         }
                         messagingService.broadcastToLobby(lobbyCode, "CARDS_DEALT", result.cardDistribution.hands)
                         messagingService.broadcast("LOBBY_LIST_UPDATE", lobbyService.getAllLobbies())
+                    }
+                }
+                "PLAY_CARD" -> {
+                    if (data != null) {
+                        val request = objectMapper.treeToValue<PlayCardRequest>(data)
+                        val lobbyCode = messagingService.getLobbyCodeForSession(session.id)
+                            ?: throw IllegalArgumentException("Session is not connected to a lobby")
+                        val sessionPlayerId = messagingService.getPlayerIdForSession(session.id)
+                            ?: throw IllegalArgumentException("Session is not linked to a player")
+
+                        require(sessionPlayerId == request.playerId) {
+                            "Player ID mismatch: session belongs to $sessionPlayerId"
+                        }
+
+                        val result = turnManager.playCard(
+                            playerId = request.playerId,
+                            cardId = request.cardId,
+                            position = request.position,
+                            isRotated = request.isRotated
+                        )
+
+                        messagingService.broadcastToLobby(lobbyCode, "GAME_STATE_UPDATE", result.updatedGameState)
+                        messagingService.broadcastToLobby(lobbyCode, "CARDS_DEALT", result.updatedHands)
+                    }
+                }
+                "DISCARD_CARD" -> {
+                    if (data != null) {
+                        val request = objectMapper.treeToValue<DiscardCardRequest>(data)
+                        val lobbyCode = messagingService.getLobbyCodeForSession(session.id)
+                            ?: throw IllegalArgumentException("Session is not connected to a lobby")
+                        val sessionPlayerId = messagingService.getPlayerIdForSession(session.id)
+                            ?: throw IllegalArgumentException("Session is not linked to a player")
+
+                        require(sessionPlayerId == request.playerId) {
+                            "Player ID mismatch: session belongs to $sessionPlayerId"
+                        }
+
+                        val result = turnManager.discardCard(
+                            playerId = request.playerId,
+                            cardId = request.cardId
+                        )
+
+                        messagingService.broadcastToLobby(lobbyCode, "GAME_STATE_UPDATE", result.updatedGameState)
+                        messagingService.broadcastToLobby(lobbyCode, "CARDS_DEALT", result.updatedHands)
                     }
                 }
                 "LOBBY_CREATE" -> {
@@ -89,10 +137,10 @@ class WebSocketHandler(
                     if (data != null) {
                         val request = objectMapper.treeToValue<LobbyLeaveRequest>(data)
                         val updatedLobby = lobbyService.leaveLobby(request.lobbyCode, request.playerId)
-                        
+
                         messagingService.leaveLobbyGroup(session.id, request.lobbyCode)
                         messagingService.sendToSession(session.id, "LOBBY_LEFT", "")
-                        
+
                         if (updatedLobby != null) {
                             messagingService.broadcastToLobby(request.lobbyCode, "LOBBY_STATE_UPDATE", updatedLobby)
                         }

--- a/server/src/test/kotlin/com/aau/server/GameBoardTest.kt
+++ b/server/src/test/kotlin/com/aau/server/GameBoardTest.kt
@@ -89,6 +89,17 @@ class GameBoardTest {
     }
 
     @Test
+    fun `cannot place card when it connects toward neighbor but neighbor does not connect back`() {
+        val b = board()
+        // Place a card at (1,0) with only LEFT connection (no RIGHT)
+        val noRight = TunnelCard("t13", CardType.PATH, setOf(Direction.LEFT))
+        b.placeCard(1, 0, noRight)
+        // Card at (2,0) has LEFT connection → cardConnects=true, neighborConnects(RIGHT in noRight)=false → mismatch
+        val withLeft = TunnelCard("t14", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        assertFalse(b.canPlaceCard(2, 0, withLeft))
+    }
+
+    @Test
     fun `cannot place card on occupied cell`() {
         // (0,0) is already occupied by the start card
         val card = TunnelCard("t7", CardType.PATH, setOf(Direction.TOP, Direction.LEFT, Direction.RIGHT, Direction.BOTTOM))

--- a/server/src/test/kotlin/com/aau/server/GameBoardTest.kt
+++ b/server/src/test/kotlin/com/aau/server/GameBoardTest.kt
@@ -189,4 +189,31 @@ class GameBoardTest {
         assertTrue(b.canPlaceCard(2, 0, second))
     }
 
+    // ── Reachability through GOAL cards ──────────────────────────────────────
+
+    @Test
+    fun `revealed GOAL card is traversable in BFS — card beyond goal is reachable`() {
+        // Layout: start(0,0) → path(1,0) → revealedGoal(2,0) → target(3,0)
+        // BFS must pass through the revealed GOAL card to reach (3,0).
+        val b = board()
+        b.placeCard(1, 0, TunnelCard("path1", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT)))
+        b.placeCard(2, 0, TunnelCard("goal1", CardType.GOAL,
+            setOf(Direction.LEFT, Direction.RIGHT), isRevealed = true))
+        val target = TunnelCard("p_beyond", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        assertTrue(b.canPlaceCard(3, 0, target))
+    }
+
+    @Test
+    fun `unrevealed GOAL card is NOT traversable in BFS — card beyond goal is unreachable`() {
+        // Same layout as above but goal is unrevealed.
+        // Adjacency at (3,0): card LEFT=true, goal RIGHT=true → both connect → XOR passes.
+        // Reachability fails because BFS cannot traverse through the unrevealed GOAL.
+        val b = board()
+        b.placeCard(1, 0, TunnelCard("path1", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT)))
+        b.placeCard(2, 0, TunnelCard("goal1", CardType.GOAL,
+            setOf(Direction.LEFT, Direction.RIGHT), isRevealed = false))
+        val target = TunnelCard("p_beyond", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        assertFalse(b.canPlaceCard(3, 0, target))
+    }
+
 }

--- a/server/src/test/kotlin/com/aau/server/GameBoardTest.kt
+++ b/server/src/test/kotlin/com/aau/server/GameBoardTest.kt
@@ -60,16 +60,15 @@ class GameBoardTest {
     }
 
     @Test
-    fun `can place card when both sides have no connection`() {
+    fun `cannot place card when neighbor has no connection toward it (reachability blocked)`() {
         val b = board()
-        // Create a card at (1,0) that has NO RIGHT connection
+        // first {LEFT} at (1,0): no RIGHT connection, so BFS cannot propagate reachability beyond it.
+        // XOR rule: (1,0) RIGHT=false, second LEFT=false → wall/wall, adjacency VALID.
+        // Fails only because (2,0) is not reachable from start (no PATH chain through (1,0)'s RIGHT).
         val first = TunnelCard("t11", CardType.PATH, setOf(Direction.LEFT))
         b.placeCard(1, 0, first)
-        
-        // Card at (2,0) has NO LEFT connection
-        // (1,0) RIGHT is NO, (2,0) LEFT is NO -> NO == NO is true
         val second = TunnelCard("t12", CardType.PATH, setOf(Direction.RIGHT))
-        assertTrue(b.canPlaceCard(2, 0, second))
+        assertFalse(b.canPlaceCard(2, 0, second))
     }
 
     // ── canPlaceCard – incompatible cases ─────────────────────────────────────
@@ -121,6 +120,72 @@ class GameBoardTest {
         b.placeCard(1, 0, first)
         // second card to the right of first; first has RIGHT, so second needs LEFT
         val second = TunnelCard("t10", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        assertTrue(b.canPlaceCard(2, 0, second))
+    }
+
+    // ── XOR adjacency rule: all four direction/connection combinations ────────
+
+    @Test
+    fun `xor rule placed has LEFT neighbor has RIGHT both connect valid`() {
+        // Both sides open → tunnel passes through → VALID
+        val card = TunnelCard("lr", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        assertTrue(board().canPlaceCard(1, 0, card))
+    }
+
+    @Test
+    fun `xor rule placed no LEFT neighbor has RIGHT open tunnel invalid`() {
+        // start RIGHT=true, card LEFT=false → XOR=true → INVALID
+        val card = TunnelCard("tb", CardType.PATH, setOf(Direction.TOP, Direction.BOTTOM))
+        assertFalse(board().canPlaceCard(1, 0, card))
+    }
+
+    @Test
+    fun `xor rule placed has LEFT neighbor no RIGHT open tunnel invalid`() {
+        val b = board()
+        // noRight {TOP,BOTTOM} at (1,0): no RIGHT. card {LEFT,RIGHT} at (2,0): card LEFT=true, noRight RIGHT=false → XOR=true → INVALID
+        b.placeCard(1, 0, TunnelCard("nr", CardType.PATH, setOf(Direction.TOP, Direction.BOTTOM)))
+        val card = TunnelCard("lr", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        assertFalse(b.canPlaceCard(2, 0, card))
+    }
+
+    @Test
+    fun `xor rule wall faces wall neither connects valid by adjacency reachable via other neighbor`() {
+        // Layout: start(0,0) → pathAll(1,0) → pathAll(2,0) [reachable]
+        //                        ↓
+        //                    pathTB(1,1) [has TOP+BOTTOM only, no RIGHT]
+        // Target (2,1):
+        //   TOP  neighbor (2,0) pathAll: BOTTOM=true,  card TOP=true   → both connect ✓ → reachable via (2,0) ✓
+        //   LEFT neighbor (1,1) pathTB:  RIGHT=false, card LEFT=false  → wall/wall XOR=false ✓
+        val b = board()
+        val allDirs = Direction.values().toSet()
+        b.placeCard(1, 0, TunnelCard("a", CardType.PATH, allDirs))
+        b.placeCard(2, 0, TunnelCard("b", CardType.PATH, allDirs))
+        b.placeCard(1, 1, TunnelCard("c", CardType.PATH, setOf(Direction.TOP, Direction.BOTTOM)))
+        val card = TunnelCard("target", CardType.PATH, setOf(Direction.TOP))
+        assertTrue(b.canPlaceCard(2, 1, card))
+    }
+
+    // ── Reachability via PATH cards only ─────────────────────────────────────
+
+    @Test
+    fun `cannot place card adjacent only to dead-end even though adjacency matches`() {
+        val b = board()
+        // dead_lr {LEFT,RIGHT} at (1,0): adjacency to start OK, but dead-end is not traversable
+        val deadEnd = TunnelCard("de1", CardType.DEAD_END, setOf(Direction.LEFT, Direction.RIGHT))
+        b.placeCard(1, 0, deadEnd)
+        // Card at (2,0) with {LEFT,RIGHT}: adjacency to dead-end passes, but reachability fails
+        val pathCard = TunnelCard("p_after_dead", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        assertFalse(b.canPlaceCard(2, 0, pathCard))
+    }
+
+    @Test
+    fun `can place card adjacent to reachable PATH card`() {
+        val b = board()
+        // path_lr {LEFT,RIGHT} at (1,0): reachable from start via PATH
+        val first = TunnelCard("p1", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        b.placeCard(1, 0, first)
+        // Card at (2,0) with {LEFT,RIGHT}: adjacent to reachable PATH card → valid
+        val second = TunnelCard("p2", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
         assertTrue(b.canPlaceCard(2, 0, second))
     }
 

--- a/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
@@ -226,4 +226,115 @@ class TurnManagerTest {
         assertEquals(1, hands[p2]!!.size)
         assertEquals(1, hands[p3]!!.size)
     }
+
+    // --- canPlaceOnBoard: position already occupied ---
+
+    @Test
+    fun `playCard positionAlreadyOccupied throwsException`() {
+        // The start card occupies startPosition – placing there must fail
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "c1", startPosition, isRotated = false)
+        }
+    }
+
+    // --- canPlaceOnBoard: connection mismatch (cardConnects != neighborConnects) ---
+
+    @Test
+    fun `playCard connectionMismatch throwsException`() {
+        // pathCard has {TOP, BOTTOM}. Placing it to the RIGHT of start at (4,3):
+        // LEFT neighbor = start (which connects RIGHT=true), card doesn't connect LEFT=false → mismatch
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "c1", BoardPosition(row = 4, column = 3), isRotated = false)
+        }
+    }
+
+    // --- flipConnections: TOP → BOTTOM branch ---
+
+    @Test
+    fun `playCard rotatedTopCard exercisesFlipConnectionsTopBranch`() {
+        // topRightCard has {TOP, RIGHT}. Rotated → {BOTTOM, LEFT}.
+        // Place at (3,2): BOTTOM neighbour = start (connects TOP) → match ✓
+        val topRightCard = TunnelCard("tr1", CardType.PATH, setOf(Direction.TOP, Direction.RIGHT))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(topRightCard), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            baseState()
+        )
+        val result = turnManager.playCard(p1, "tr1", BoardPosition(row = 3, column = 2), isRotated = true)
+        val placed = result.updatedGameState.boardPlacements.find { it.position == BoardPosition(3, 2) }
+        assertNotNull(placed)
+        assertTrue(placed!!.card.isRotated)
+        // After flip: connections must be {BOTTOM, LEFT}
+        assertEquals(setOf(Direction.BOTTOM, Direction.LEFT), placed!!.card.connections)
+    }
+
+    // --- flipConnections: BOTTOM → TOP branch ---
+
+    @Test
+    fun `playCard rotatedBottomCard exercisesFlipConnectionsBottomBranch`() {
+        // bottomLeftCard has {BOTTOM, LEFT}. Rotated → {TOP, RIGHT}.
+        // Place at (5,2): TOP neighbour = start (connects BOTTOM) → match ✓
+        val bottomLeftCard = TunnelCard("bl1", CardType.PATH, setOf(Direction.BOTTOM, Direction.LEFT))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(bottomLeftCard), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            baseState()
+        )
+        val result = turnManager.playCard(p1, "bl1", BoardPosition(row = 5, column = 2), isRotated = true)
+        val placed = result.updatedGameState.boardPlacements.find { it.position == BoardPosition(5, 2) }
+        assertNotNull(placed)
+        assertEquals(setOf(Direction.TOP, Direction.RIGHT), placed!!.card.connections)
+    }
+
+    // --- opposite(TOP) branch: card placed below an existing card → dir=TOP ---
+
+    @Test
+    fun `canPlaceOnBoard cardBelowStart exercisesOppositeTopBranch`() {
+        // Placing pathCard {TOP,BOTTOM} at (5,2): TOP neighbour = start → opposite(TOP)=BOTTOM
+        // start connects BOTTOM, card connects TOP → match
+        val result = turnManager.playCard(p1, "c1", BoardPosition(row = 5, column = 2), isRotated = false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == BoardPosition(5, 2) })
+    }
+
+    // --- opposite(RIGHT) branch: card placed left of existing card → dir=RIGHT ---
+
+    @Test
+    fun `canPlaceOnBoard cardLeftOfStart exercisesOppositeRightBranch`() {
+        // hPathCard {LEFT,RIGHT} at (4,1): RIGHT neighbour = start → opposite(RIGHT)=LEFT
+        // start connects LEFT, card connects RIGHT → match
+        val lr = hPathCard("lr1")
+        turnManager.initializeGame(
+            distribution(h1 = listOf(lr), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            baseState()
+        )
+        val result = turnManager.playCard(p1, "lr1", BoardPosition(row = 4, column = 1), isRotated = false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == BoardPosition(4, 1) })
+    }
+
+    // --- nextPlayerId: currentPlayerId not found in players → fallback to first ---
+
+    @Test
+    fun `nextPlayerId unknownCurrentPlayer fallsBackToFirst`() {
+        val ghost = "ghost"
+        val specialState = GameState(
+            players = listOf(
+                PlayerTurn(p1, "Alice", 1),
+                PlayerTurn(p2, "Bob", 2),
+                PlayerTurn(p3, "Charlie", 3)
+            ),
+            currentPlayerId = ghost,
+            boardPlacements = listOf(PlacedTunnelCard(startPosition, startCard))
+        )
+        val specialDist = CardDistributionResult(
+            hands = mapOf(p1 to listOf(pathCard("c1")), p2 to listOf(pathCard("c2")),
+                p3 to listOf(pathCard("c3")), ghost to listOf(pathCard("cg"))),
+            drawPile = emptyList(),
+            goalCards = CardDeck.createGoalCards(),
+            startCard = startCard
+        )
+        turnManager.initializeGame(specialDist, specialState)
+
+        // Discard as the ghost player – passes the currentPlayer require check.
+        // nextPlayerId will find idx == -1 and fall back to the first player by turnOrder.
+        val result = turnManager.discardCard(ghost, "cg")
+        assertEquals(p1, result.updatedGameState.currentPlayerId)
+    }
 }

--- a/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
@@ -739,6 +739,177 @@ class TurnManagerTest {
         }
     }
 
+    // --- player not in hands map ---
+
+    @Test
+    fun `playCard playerNotInHands throwsException`() {
+        // p1 is currentPlayer but missing from the hands map → null branch at L48
+        val dist = CardDistributionResult(
+            hands = mapOf(p2 to listOf(pathCard("c2")), p3 to listOf(pathCard("c3"))),
+            drawPile = emptyList(),
+            goalCards = CardDeck.createGoalCards(),
+            startCard = startCard
+        )
+        turnManager.initializeGame(dist, baseState(currentPlayer = p1))
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "c1", BoardPosition(row = 3, column = 2), false)
+        }
+    }
+
+    @Test
+    fun `discardCard playerNotInHands throwsException`() {
+        // p1 is currentPlayer but missing from the hands map → null branch at L91
+        val dist = CardDistributionResult(
+            hands = mapOf(p2 to listOf(pathCard("c2")), p3 to listOf(pathCard("c3"))),
+            drawPile = emptyList(),
+            goalCards = CardDeck.createGoalCards(),
+            startCard = startCard
+        )
+        turnManager.initializeGame(dist, baseState(currentPlayer = p1))
+        assertThrows<IllegalArgumentException> {
+            turnManager.discardCard(p1, "c1")
+        }
+    }
+
+    // --- nextPlayerId with empty players list → firstOrNull() is null ---
+
+    @Test
+    fun `nextPlayerId emptyPlayersList returnsNull`() {
+        // players=emptyList() → sorted.firstOrNull() returns null → ?.playerId = null
+        val emptyState = GameState(
+            players = emptyList(),
+            currentPlayerId = "ghost",
+            boardPlacements = listOf(PlacedTunnelCard(startPosition, startCard))
+        )
+        val dist = CardDistributionResult(
+            hands = mapOf("ghost" to listOf(pathCard("cg"))),
+            drawPile = emptyList(),
+            goalCards = CardDeck.createGoalCards(),
+            startCard = startCard
+        )
+        turnManager.initializeGame(dist, emptyState)
+        val result = turnManager.discardCard("ghost", "cg")
+        assertNull(result.updatedGameState.currentPlayerId)
+    }
+
+    // --- isReachableFromStart: no START card → return false immediately ---
+
+    @Test
+    fun `isReachableFromStart noStartCard returnsFalse`() {
+        // Board has only a PATH card – no START → BFS returns false immediately (L167 ?: return false)
+        val pathOnly = hPathCard("p_only")
+        val stateNoStart = GameState(
+            players = listOf(PlayerTurn(p1, "Alice", 1), PlayerTurn(p2, "Bob", 2), PlayerTurn(p3, "Charlie", 3)),
+            currentPlayerId = p1,
+            boardPlacements = listOf(PlacedTunnelCard(BoardPosition(row = 4, column = 3), pathOnly))
+        )
+        val card = hPathCard("lr_t")
+        val dist = CardDistributionResult(
+            hands = mapOf(p1 to listOf(card), p2 to listOf(pathCard("c2")), p3 to listOf(pathCard("c3"))),
+            drawPile = emptyList(),
+            goalCards = CardDeck.createGoalCards(),
+            startCard = startCard
+        )
+        turnManager.initializeGame(dist, stateNoStart)
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "lr_t", BoardPosition(row = 4, column = 4), false)
+        }
+    }
+
+    // --- isReachableFromStart: START card reached as unvisited neighbor (L182 START branch) ---
+
+    @Test
+    fun `isReachableFromStart startCardReachedAsNeighbor exercisesStartTypeBranch`() {
+        // Board: startCard@(4,2) → hPath@(4,3) → start2@(4,4)
+        // BFS starts at startCard. Processes hPath; its RIGHT neighbor is start2 whose type==START.
+        // That exercises the neighborCard.type==START true branch (L182).
+        val start2 = TunnelCard("start2", CardType.START, Direction.values().toSet())
+        val boardState = GameState(
+            players = listOf(PlayerTurn(p1, "Alice", 1), PlayerTurn(p2, "Bob", 2), PlayerTurn(p3, "Charlie", 3)),
+            currentPlayerId = p1,
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 3), hPathCard("mp")),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 4), start2)
+            )
+        )
+        val card = TunnelCard("lft", CardType.PATH, setOf(Direction.LEFT))
+        val dist = CardDistributionResult(
+            hands = mapOf(p1 to listOf(card), p2 to listOf(pathCard("c2")), p3 to listOf(pathCard("c3"))),
+            drawPile = emptyList(),
+            goalCards = CardDeck.createGoalCards(),
+            startCard = startCard
+        )
+        turnManager.initializeGame(dist, boardState)
+        // (4,5): LEFT neighbor is start2@(4,4) which connects RIGHT back → valid placement
+        val result = turnManager.playCard(p1, "lft", BoardPosition(row = 4, column = 5), false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == BoardPosition(4, 5) })
+    }
+
+    // --- isReachableFromStart: A=true, B=false in connection check (L185) ---
+
+    @Test
+    fun `isReachableFromStart pathWithEmptyConnections exercisesL185ATrueBFalse`() {
+        // pathBridge{L,R} is reachable from start. pathEmpty{} is adjacent to its RIGHT.
+        // BFS at pathBridge: dir=RIGHT, A = RIGHT in {L,R} = true.
+        //                    B = opposite(RIGHT)=LEFT in {} = false → L185 A=true, B=false.
+        // pathEmpty never added to queue; (3,3) is unreachable → require throws.
+        val pathBridge = TunnelCard("pb_l185", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        val pathEmpty  = TunnelCard("pe_l185", CardType.PATH, emptySet())
+        val boardState = GameState(
+            players = listOf(PlayerTurn(p1, "Alice", 1), PlayerTurn(p2, "Bob", 2), PlayerTurn(p3, "Charlie", 3)),
+            currentPlayerId = p1,
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 3), pathBridge),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 4), pathEmpty)
+            )
+        )
+        // card{T} at (3,3): BOTTOM neighbor=pathBridge{L,R}. card BOTTOM=false, neighbor TOP=false → wall/wall → adjacencyOk.
+        // isReachableFromStart called; (3,3) unreachable → throws.
+        val card = TunnelCard("tc_l185", CardType.PATH, setOf(Direction.TOP))
+        val dist = CardDistributionResult(
+            hands = mapOf(p1 to listOf(card), p2 to listOf(pathCard("c2")), p3 to listOf(pathCard("c3"))),
+            drawPile = emptyList(), goalCards = CardDeck.createGoalCards(), startCard = startCard
+        )
+        turnManager.initializeGame(dist, boardState)
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "tc_l185", BoardPosition(row = 3, column = 3), false)
+        }
+    }
+
+    @Test
+    fun `isReachableFromStart traversableNeighborConnectsForwardButNotBack exercisesL185Branch`() {
+        // revGoal@(4,4){L,R,B} has BOTTOM toward pathMismatch@(5,4){L}.
+        // pathMismatch is ONLY reachable through revGoal, so it is NOT yet in visited when revGoal expands.
+        // dir=BOTTOM in revGoal=true (A=true); opposite(BOTTOM)=TOP in pathMismatch{L}=false (B=false) → L185.
+        val pathBridge   = TunnelCard("pbx", CardType.PATH, Direction.values().toSet())
+        val revGoal      = TunnelCard("rgx", CardType.GOAL,
+            setOf(Direction.LEFT, Direction.RIGHT, Direction.BOTTOM), isRevealed = true)
+        val pathMismatch = TunnelCard("pmx", CardType.PATH, setOf(Direction.LEFT))
+        val boardState = GameState(
+            players = listOf(PlayerTurn(p1, "Alice", 1), PlayerTurn(p2, "Bob", 2), PlayerTurn(p3, "Charlie", 3)),
+            currentPlayerId = p1,
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 3), pathBridge),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 4), revGoal),
+                PlacedTunnelCard(BoardPosition(row = 5, column = 4), pathMismatch)
+            )
+        )
+        // Target (4,5): LEFT neighbor revGoal{L,R,B}. card LEFT=true, revGoal RIGHT=true → valid.
+        val card = TunnelCard("lcx", CardType.PATH, setOf(Direction.LEFT))
+        val dist = CardDistributionResult(
+            hands = mapOf(p1 to listOf(card), p2 to listOf(pathCard("c2")), p3 to listOf(pathCard("c3"))),
+            drawPile = emptyList(),
+            goalCards = CardDeck.createGoalCards(),
+            startCard = startCard
+        )
+        turnManager.initializeGame(dist, boardState)
+        val result = turnManager.playCard(p1, "lcx", BoardPosition(row = 4, column = 5), false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == BoardPosition(4, 5) })
+    }
+
     @Test
     fun `nextPlayerId unknownCurrentPlayer fallsBackToFirst`() {
         val ghost = "ghost"

--- a/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
@@ -248,6 +248,64 @@ class TurnManagerTest {
         }
     }
 
+    // --- canPlaceOnBoard: bidirectional connectivity ---
+
+    @Test
+    fun `playCard cardConnectsTowardNeighborButNeighborDoesNotConnectBack throwsException`() {
+        // Setup: a {TOP, BOTTOM} card at (4,3) – no RIGHT connection.
+        // Place hPathCard {LEFT,RIGHT} at (4,4): LEFT→neighbor connects=true, neighbor RIGHT=false → mismatch
+        val tbAtRight = TunnelCard("tb_right", CardType.PATH, setOf(Direction.TOP, Direction.BOTTOM))
+        val stateWithExtra = baseState().copy(
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 3), tbAtRight)
+            )
+        )
+        val lr = hPathCard("lr_test")
+        turnManager.initializeGame(
+            distribution(h1 = listOf(lr), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithExtra
+        )
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "lr_test", BoardPosition(row = 4, column = 4), isRotated = false)
+        }
+    }
+
+    @Test
+    fun `playCard noSharedConnectionOnEitherSide isAllowed`() {
+        // Setup: a {TOP, BOTTOM} card at (4,3) – no RIGHT connection.
+        // Place another {TOP,BOTTOM} card at (4,4): both have no connection toward the shared LEFT/RIGHT edge.
+        // Neither connects → both false → compatible (dead-end adjacency is valid by game rules).
+        val tbAtRight = TunnelCard("tb_right2", CardType.PATH, setOf(Direction.TOP, Direction.BOTTOM))
+        val stateWithExtra = baseState().copy(
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 3), tbAtRight)
+            )
+        )
+        val tbNew = pathCard("tb_new")
+        turnManager.initializeGame(
+            distribution(h1 = listOf(tbNew), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithExtra
+        )
+        val result = turnManager.playCard(p1, "tb_new", BoardPosition(row = 4, column = 4), isRotated = false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == BoardPosition(4, 4) })
+    }
+
+    // --- action card placement guard ---
+
+    @Test
+    fun `playCard actionCardType throwsException`() {
+        val actionCard = TunnelCard("rock1", CardType.ROCKFALL, emptySet())
+        turnManager.initializeGame(
+            distribution(h1 = listOf(actionCard), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            baseState()
+        )
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "rock1", BoardPosition(row = 3, column = 2), isRotated = false)
+        }
+    }
+
     // --- flipConnections: TOP → BOTTOM branch ---
 
     @Test

--- a/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
@@ -1,0 +1,229 @@
+package com.aau.server
+
+import com.aau.saboteur.model.*
+import com.aau.server.game.CardDeck
+import com.aau.server.model.CardDistributionResult
+import com.aau.server.service.TurnManager
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class TurnManagerTest {
+
+    private lateinit var turnManager: TurnManager
+
+    private val p1 = "player1"
+    private val p2 = "player2"
+    private val p3 = "player3"
+
+    // Start card at (4,2) with all four connections – cards adjacent to it are valid placements
+    private val startCard = CardDeck.createStartCard()
+    private val startPosition = BoardPosition(row = 4, column = 2)
+
+    // A simple straight card that connects TOP and BOTTOM – fits above/below the start card
+    private fun pathCard(id: String) = TunnelCard(
+        id = id,
+        type = CardType.PATH,
+        connections = setOf(Direction.TOP, Direction.BOTTOM)
+    )
+
+    // A straight card that connects LEFT and RIGHT – fits left/right of the start card
+    private fun hPathCard(id: String) = TunnelCard(
+        id = id,
+        type = CardType.PATH,
+        connections = setOf(Direction.LEFT, Direction.RIGHT)
+    )
+
+    private fun baseState(currentPlayer: String = p1) = GameState(
+        players = listOf(
+            PlayerTurn(p1, "Alice", 1),
+            PlayerTurn(p2, "Bob", 2),
+            PlayerTurn(p3, "Charlie", 3)
+        ),
+        currentPlayerId = currentPlayer,
+        boardPlacements = listOf(PlacedTunnelCard(startPosition, startCard))
+    )
+
+    private fun distribution(
+        h1: List<TunnelCard> = emptyList(),
+        h2: List<TunnelCard> = emptyList(),
+        h3: List<TunnelCard> = emptyList(),
+        pile: List<TunnelCard> = emptyList()
+    ) = CardDistributionResult(
+        hands = mapOf(p1 to h1, p2 to h2, p3 to h3),
+        drawPile = pile,
+        goalCards = CardDeck.createGoalCards(),
+        startCard = startCard
+    )
+
+    @BeforeEach
+    fun setUp() {
+        turnManager = TurnManager()
+        turnManager.initializeGame(
+            distribution(
+                h1 = listOf(pathCard("c1")),
+                h2 = listOf(pathCard("c2")),
+                h3 = listOf(pathCard("c3"))
+            ),
+            baseState()
+        )
+    }
+
+    // --- playCard tests ---
+
+    @Test
+    fun `playCard validMove removesCardFromHandAndPlacesOnBoard`() {
+        // Above the start card: row=3, column=2; the placed card needs BOTTOM to connect to start's TOP
+        val position = BoardPosition(row = 3, column = 2)
+        val result = turnManager.playCard(p1, "c1", position, isRotated = false)
+
+        val hand1 = result.updatedHands[p1]!!
+        assertFalse(hand1.any { it.id == "c1" }, "Card should be removed from hand after play")
+
+        val placed = result.updatedGameState.boardPlacements.find { it.position == position }
+        assertNotNull(placed, "Card should appear on the board")
+        assertEquals("c1", placed!!.card.id)
+    }
+
+    @Test
+    fun `playCard wrongPlayer throwsException`() {
+        assertThrows<IllegalArgumentException>("Not this player's turn") {
+            turnManager.playCard(p2, "c2", BoardPosition(row = 3, column = 2), false)
+        }
+    }
+
+    @Test
+    fun `playCard cardNotInHand throwsException`() {
+        assertThrows<IllegalArgumentException>("Card not found in hand") {
+            turnManager.playCard(p1, "does_not_exist", BoardPosition(row = 3, column = 2), false)
+        }
+    }
+
+    @Test
+    fun `playCard invalidPosition throwsException`() {
+        // (0,0) has no neighbor in our board
+        assertThrows<IllegalArgumentException>("Invalid position should be rejected") {
+            turnManager.playCard(p1, "c1", BoardPosition(row = 0, column = 0), false)
+        }
+    }
+
+    @Test
+    fun `playCard rotatedCard usesEffectiveConnections`() {
+        // hPathCard has LEFT+RIGHT connections. Rotated 180° it still has LEFT+RIGHT (symmetric).
+        // Place it to the right of start: position (4,3). Start has RIGHT, card needs LEFT.
+        turnManager.initializeGame(
+            distribution(h1 = listOf(hPathCard("h1")), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            baseState()
+        )
+        val result = turnManager.playCard(p1, "h1", BoardPosition(row = 4, column = 3), isRotated = true)
+        val placed = result.updatedGameState.boardPlacements.find { it.position == BoardPosition(4, 3) }
+        assertNotNull(placed)
+        assertTrue(placed!!.card.isRotated)
+    }
+
+    // --- discardCard tests ---
+
+    @Test
+    fun `discardCard validDiscard removesCardFromHand`() {
+        val result = turnManager.discardCard(p1, "c1")
+        assertFalse(result.updatedHands[p1]!!.any { it.id == "c1" }, "Discarded card should be gone")
+    }
+
+    @Test
+    fun `discardCard wrongPlayer throwsException`() {
+        assertThrows<IllegalArgumentException> {
+            turnManager.discardCard(p2, "c2")
+        }
+    }
+
+    @Test
+    fun `discardCard cardNotInHand throwsException`() {
+        assertThrows<IllegalArgumentException> {
+            turnManager.discardCard(p1, "nonexistent")
+        }
+    }
+
+    // --- drawCard behaviour (tested via discard side-effects) ---
+
+    @Test
+    fun `drawCard deckNotEmpty addsCardToHand`() {
+        turnManager.initializeGame(
+            distribution(
+                h1 = listOf(pathCard("c1")),
+                h2 = listOf(pathCard("c2")),
+                h3 = listOf(pathCard("c3")),
+                pile = listOf(pathCard("deck1"))
+            ),
+            baseState()
+        )
+        val sizeBefore = turnManager.getHands()[p1]!!.size
+        turnManager.discardCard(p1, "c1")
+        val sizeAfter = turnManager.getHands()[p1]!!.size
+
+        assertEquals(sizeBefore, sizeAfter, "Discard + draw should keep hand size the same when deck has cards")
+        assertTrue(turnManager.getHands()[p1]!!.any { it.id == "deck1" }, "Drawn card should be in hand")
+    }
+
+    @Test
+    fun `drawCard deckEmpty handUnchanged`() {
+        // setUp has empty draw pile
+        val sizeBefore = turnManager.getHands()[p1]!!.size
+        turnManager.discardCard(p1, "c1")
+        val sizeAfter = turnManager.getHands()[p1]!!.size
+
+        assertEquals(sizeBefore - 1, sizeAfter, "Hand should shrink by 1 when deck is empty")
+    }
+
+    // --- nextPlayer tests ---
+
+    @Test
+    fun `nextPlayer advancesToNextPlayerInOrder`() {
+        turnManager.discardCard(p1, "c1")
+        assertEquals(p2, turnManager.getGameState().currentPlayerId)
+    }
+
+    @Test
+    fun `nextPlayer lastPlayer wrapsAroundToFirst`() {
+        turnManager.initializeGame(
+            distribution(
+                h1 = listOf(pathCard("c1")),
+                h2 = listOf(pathCard("c2")),
+                h3 = listOf(pathCard("c3x"))
+            ),
+            baseState(currentPlayer = p3)
+        )
+        turnManager.discardCard(p3, "c3x")
+        assertEquals(p1, turnManager.getGameState().currentPlayerId, "Should wrap around to first player")
+    }
+
+    @Test
+    fun `nextPlayer advancesThroughAllThreePlayers`() {
+        turnManager.initializeGame(
+            distribution(
+                h1 = listOf(pathCard("a1"), pathCard("a2")),
+                h2 = listOf(pathCard("b1"), pathCard("b2")),
+                h3 = listOf(pathCard("c1x"), pathCard("c2"))
+            ),
+            baseState()
+        )
+
+        assertEquals(p1, turnManager.getGameState().currentPlayerId)
+        turnManager.discardCard(p1, "a1")
+        assertEquals(p2, turnManager.getGameState().currentPlayerId)
+        turnManager.discardCard(p2, "b1")
+        assertEquals(p3, turnManager.getGameState().currentPlayerId)
+        turnManager.discardCard(p3, "c1x")
+        assertEquals(p1, turnManager.getGameState().currentPlayerId)
+    }
+
+    // --- getHands ---
+
+    @Test
+    fun `getHands returnsImmutableSnapshot`() {
+        val hands = turnManager.getHands()
+        assertEquals(1, hands[p1]!!.size)
+        assertEquals(1, hands[p2]!!.size)
+        assertEquals(1, hands[p3]!!.size)
+    }
+}

--- a/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
@@ -272,10 +272,11 @@ class TurnManagerTest {
     }
 
     @Test
-    fun `playCard noSharedConnectionOnEitherSide isAllowed`() {
-        // Setup: a {TOP, BOTTOM} card at (4,3) – no RIGHT connection.
-        // Place another {TOP,BOTTOM} card at (4,4): both have no connection toward the shared LEFT/RIGHT edge.
-        // Neither connects → both false → compatible (dead-end adjacency is valid by game rules).
+    fun `playCard noSharedConnectionOnEitherSide throwsException`() {
+        // XOR rule: wall/wall (neither side connects) is valid adjacency-wise.
+        // Setup: {TOP,BOTTOM} at (4,3) – no RIGHT. Another {TOP,BOTTOM} at (4,4): neither connects at shared edge.
+        // Adjacency: false == false → VALID. But (4,3) is unreachable from start (start RIGHT != (4,3) LEFT=false),
+        // so reachability fails → exception.
         val tbAtRight = TunnelCard("tb_right2", CardType.PATH, setOf(Direction.TOP, Direction.BOTTOM))
         val stateWithExtra = baseState().copy(
             boardPlacements = listOf(
@@ -288,8 +289,23 @@ class TurnManagerTest {
             distribution(h1 = listOf(tbNew), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
             stateWithExtra
         )
-        val result = turnManager.playCard(p1, "tb_new", BoardPosition(row = 4, column = 4), isRotated = false)
-        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == BoardPosition(4, 4) })
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "tb_new", BoardPosition(row = 4, column = 4), isRotated = false)
+        }
+    }
+
+    @Test
+    fun `playCard rotatedCardInvalidAfterFlip throwsException`() {
+        // bottomLeftCard {BOTTOM, LEFT} unrotated placed above start (3,2) would be VALID
+        // (BOTTOM connects to start's TOP). Rotated → {TOP, RIGHT}: BOTTOM is gone → INVALID.
+        val bottomLeftCard = TunnelCard("bl_rot", CardType.PATH, setOf(Direction.BOTTOM, Direction.LEFT))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(bottomLeftCard), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            baseState()
+        )
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "bl_rot", BoardPosition(row = 3, column = 2), isRotated = true)
+        }
     }
 
     // --- action card placement guard ---
@@ -365,6 +381,76 @@ class TurnManagerTest {
         )
         val result = turnManager.playCard(p1, "lr1", BoardPosition(row = 4, column = 1), isRotated = false)
         assertNotNull(result.updatedGameState.boardPlacements.find { it.position == BoardPosition(4, 1) })
+    }
+
+    // --- XOR adjacency rule: wall/wall valid when reachable via another neighbor ---
+
+    @Test
+    fun `playCard wallFacesWall withReachabilityViaOtherNeighbor isAllowed`() {
+        // path_all at (4,3): reachable from start (start RIGHT / path_all LEFT both true)
+        // wall_above {LEFT,RIGHT} at (3,4): no BOTTOM → wall on TOP edge of (4,4)
+        // New card {LEFT} at (4,4):
+        //   LEFT  neighbor (4,3): path_all RIGHT=true, card LEFT=true  → both connect ✓ → reachable via (4,3) ✓
+        //   TOP   neighbor (3,4): wallAbove BOTTOM=false, card TOP=false → wall/wall XOR=false ✓
+        val pathAll  = TunnelCard("all", CardType.PATH, Direction.values().toSet())
+        val wallAbove = TunnelCard("wall_above", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        val stateWithSetup = baseState().copy(
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 3), pathAll),
+                PlacedTunnelCard(BoardPosition(row = 3, column = 4), wallAbove)
+            )
+        )
+        val card = TunnelCard("left_only", CardType.PATH, setOf(Direction.LEFT))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(card), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithSetup
+        )
+        val result = turnManager.playCard(p1, "left_only", BoardPosition(row = 4, column = 4), isRotated = false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == BoardPosition(4, 4) })
+    }
+
+    // --- reachability: dead-end cards block the path graph ---
+
+    @Test
+    fun `playCard cellOnlyAdjacentToDeadEnd throwsException`() {
+        // dead_lr {LEFT,RIGHT} at (4,3): adjacency to start passes, but dead-end is not traversable.
+        // hPathCard {LEFT,RIGHT} at (4,4): adjacency to dead-end passes, but reachability from START fails.
+        val deadEnd = TunnelCard("dead_lr", CardType.DEAD_END, setOf(Direction.LEFT, Direction.RIGHT))
+        val stateWithDeadEnd = baseState().copy(
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 3), deadEnd)
+            )
+        )
+        val lr = hPathCard("lr_after_dead")
+        turnManager.initializeGame(
+            distribution(h1 = listOf(lr), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithDeadEnd
+        )
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "lr_after_dead", BoardPosition(row = 4, column = 4), isRotated = false)
+        }
+    }
+
+    @Test
+    fun `playCard cellReachableViaPathCards isAllowed`() {
+        // hPathCard {LEFT,RIGHT} at (4,3): reachable from start via PATH.
+        // Another hPathCard {LEFT,RIGHT} at (4,4): adjacent to reachable PATH card → valid placement.
+        val pathAtRight = hPathCard("path_at_right")
+        val stateWithPath = baseState().copy(
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 3), pathAtRight)
+            )
+        )
+        val lr = hPathCard("lr_after_path")
+        turnManager.initializeGame(
+            distribution(h1 = listOf(lr), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithPath
+        )
+        val result = turnManager.playCard(p1, "lr_after_path", BoardPosition(row = 4, column = 4), isRotated = false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == BoardPosition(4, 4) })
     }
 
     // --- nextPlayerId: currentPlayerId not found in players → fallback to first ---

--- a/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
@@ -591,6 +591,154 @@ class TurnManagerTest {
         assertFalse(result.updatedGameState.boardPlacements.find { it.position == goalPos }!!.card.isRevealed)
     }
 
+    // ── revealed goal as neighbour – effective-connections contract ───────────
+    //
+    // Connections are always stored as the effective (post-rotation) value.
+    // isRotated is a rendering hint only – the validator must NOT re-apply the
+    // rotation; it reads .connections directly and gets the right answer.
+
+    // Goal at (3,3) – placed card goes BELOW it at (4,3) so dir=TOP in the check
+    private val aboveGoalPos = BoardPosition(row = 3, column = 3)
+
+    // ── reachability through revealed goal ────────────────────────────────────
+
+    @Test
+    fun `isReachableFromStart revealedGoalIsTraversed placedBeyondGoalIsValid`() {
+        // PATH at (4,3) connects to revealed goal at (4,4) {LEFT,BOTTOM}.
+        // The ONLY path to (5,4) goes through the goal's BOTTOM connection.
+        // This test fails if goal cards are excluded from the BFS.
+        val pathBetween = TunnelCard("pb", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        val revealedGoal = TunnelCard("g1", CardType.GOAL, setOf(Direction.LEFT, Direction.BOTTOM), isRevealed = true)
+        val boardState = GameState(
+            players = listOf(PlayerTurn(p1, "Alice", 1), PlayerTurn(p2, "Bob", 2), PlayerTurn(p3, "Charlie", 3)),
+            currentPlayerId = p1,
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 3), pathBetween),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 4), revealedGoal)
+            )
+        )
+        val topCard = TunnelCard("tc", CardType.PATH, setOf(Direction.TOP))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(topCard), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            boardState
+        )
+        val result = turnManager.playCard(p1, "tc", BoardPosition(row = 5, column = 4), isRotated = false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == BoardPosition(5, 4) })
+    }
+
+    @Test
+    fun `isReachableFromStart unrevealedGoalNotTraversed placedBeyondGoalIsInvalid`() {
+        // Same layout but the goal is unrevealed — BFS must not traverse it.
+        val pathBetween = TunnelCard("pb", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT))
+        val unrevealedGoal = TunnelCard("g1", CardType.GOAL, setOf(Direction.LEFT, Direction.BOTTOM), isRevealed = false)
+        val boardState = GameState(
+            players = listOf(PlayerTurn(p1, "Alice", 1), PlayerTurn(p2, "Bob", 2), PlayerTurn(p3, "Charlie", 3)),
+            currentPlayerId = p1,
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 3), pathBetween),
+                PlacedTunnelCard(BoardPosition(row = 4, column = 4), unrevealedGoal)
+            )
+        )
+        // {LEFT} has no RIGHT toward goal → wall/wall adjacency passes; (5,4) blocked by reachability
+        val leftOnly = TunnelCard("lo", CardType.PATH, setOf(Direction.LEFT))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(leftOnly), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            boardState
+        )
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "lo", BoardPosition(row = 5, column = 4), isRotated = false)
+        }
+    }
+
+    @Test
+    fun `canPlaceOnBoard revealedGoalConnectsBack isValid`() {
+        // goal {LEFT, BOTTOM} revealed at (4,4). hPathCard RIGHT connects to goal LEFT → match → VALID
+        val revealed = TunnelCard("g1", CardType.GOAL, setOf(Direction.LEFT, Direction.BOTTOM), isRevealed = true)
+        turnManager.initializeGame(
+            distribution(h1 = listOf(hPathCard("h1")), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(revealed)
+        )
+        val result = turnManager.playCard(p1, "h1", placePos, isRotated = false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == placePos })
+    }
+
+    @Test
+    fun `canPlaceOnBoard revealedRotatedGoalStoredConnectionsUsed throwsException`() {
+        // Stored (effective) connections after rotation: {RIGHT, TOP} – no LEFT.
+        // hPathCard RIGHT connects toward goal, goal has no LEFT → mismatch → INVALID.
+        // If the validator incorrectly re-applied rotation it would read {LEFT, BOTTOM} and
+        // incorrectly pass.
+        val rotated = TunnelCard("g1", CardType.GOAL, setOf(Direction.RIGHT, Direction.TOP),
+            isRevealed = true, isRotated = true)
+        turnManager.initializeGame(
+            distribution(h1 = listOf(hPathCard("h1")), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(rotated)
+        )
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "h1", placePos, isRotated = false)
+        }
+    }
+
+    @Test
+    fun `canPlaceOnBoard revealedRotatedGoalWallFacesWall isValid`() {
+        // Rotated goal {RIGHT, TOP} at (4,4): no LEFT. Card {LEFT} has no RIGHT → wall/wall → VALID.
+        val rotated = TunnelCard("g1", CardType.GOAL, setOf(Direction.RIGHT, Direction.TOP),
+            isRevealed = true, isRotated = true)
+        val leftOnly = TunnelCard("lft2", CardType.PATH, setOf(Direction.LEFT))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(leftOnly), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(rotated)
+        )
+        val result = turnManager.playCard(p1, "lft2", placePos, isRotated = false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == placePos })
+    }
+
+    @Test
+    fun `canPlaceOnBoard revealedGoalGoldAllDirections isAlwaysValid`() {
+        // goal_gold connects all four directions → neighborConnects always true → VALID for any card connecting toward it
+        val gold = TunnelCard("goal_gold", CardType.GOAL,
+            setOf(Direction.TOP, Direction.RIGHT, Direction.BOTTOM, Direction.LEFT),
+            isRevealed = true, isGoal = true)
+        turnManager.initializeGame(
+            distribution(h1 = listOf(hPathCard("h1")), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(gold)
+        )
+        val result = turnManager.playCard(p1, "h1", placePos, isRotated = false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == placePos })
+    }
+
+    @Test
+    fun `canPlaceOnBoard goalHasBottomConnection placedBelowIsValid`() {
+        // Goal {BOTTOM, RIGHT} at (3,3). Card {LEFT, TOP} placed at (4,3): TOP toward goal,
+        // goal BOTTOM connects back → match → VALID.
+        val goal = TunnelCard("g1", CardType.GOAL, setOf(Direction.BOTTOM, Direction.RIGHT), isRevealed = true)
+        val topCard = TunnelCard("tp1", CardType.PATH, setOf(Direction.LEFT, Direction.TOP))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(topCard), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(goal, aboveGoalPos)
+        )
+        val result = turnManager.playCard(p1, "tp1", placePos, isRotated = false)
+        assertNotNull(result.updatedGameState.boardPlacements.find { it.position == placePos })
+    }
+
+    @Test
+    fun `canPlaceOnBoard rotatedGoalBottomRemoved placedBelowThrowsException`() {
+        // Goal was {BOTTOM, RIGHT}; after 180° rotation stored as {TOP, LEFT} – no BOTTOM.
+        // Card {LEFT, TOP} at (4,3): TOP toward goal, goal has no BOTTOM → mismatch → INVALID.
+        val rotated = TunnelCard("g1", CardType.GOAL, setOf(Direction.TOP, Direction.LEFT),
+            isRevealed = true, isRotated = true)
+        val topCard = TunnelCard("tp2", CardType.PATH, setOf(Direction.LEFT, Direction.TOP))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(topCard), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(rotated, aboveGoalPos)
+        )
+        assertThrows<IllegalArgumentException> {
+            turnManager.playCard(p1, "tp2", placePos, isRotated = false)
+        }
+    }
+
     @Test
     fun `nextPlayerId unknownCurrentPlayer fallsBackToFirst`() {
         val ghost = "ghost"

--- a/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/TurnManagerTest.kt
@@ -455,6 +455,142 @@ class TurnManagerTest {
 
     // --- nextPlayerId: currentPlayerId not found in players → fallback to first ---
 
+    // ── goal reveal ───────────────────────────────────────────────────────────
+
+    // Goal at (4,4) – one step to the right of the start-adjacent cell (4,3)
+    private val goalPos = BoardPosition(row = 4, column = 4)
+    private val placePos = BoardPosition(row = 4, column = 3)  // between start and goal
+
+    private fun goalStone(id: String, connections: Set<Direction>) = TunnelCard(
+        id = id, type = CardType.GOAL, connections = connections, isRevealed = false, isGoal = false
+    )
+
+    private fun goalGold() = TunnelCard(
+        id = "goal_gold", type = CardType.GOAL,
+        connections = setOf(Direction.TOP, Direction.RIGHT, Direction.BOTTOM, Direction.LEFT),
+        isRevealed = false, isGoal = true
+    )
+
+    private fun stateWithGoal(goal: TunnelCard, gPos: BoardPosition = goalPos, currentPlayer: String = p1) = GameState(
+        players = listOf(PlayerTurn(p1, "Alice", 1), PlayerTurn(p2, "Bob", 2), PlayerTurn(p3, "Charlie", 3)),
+        currentPlayerId = currentPlayer,
+        boardPlacements = listOf(
+            PlacedTunnelCard(startPosition, startCard),
+            PlacedTunnelCard(gPos, goal)
+        )
+    )
+
+    @Test
+    fun `playCard pathConnectsTowardGoalThatConnectsBack revealsWithoutRotation`() {
+        // goal has LEFT → goalConnects = true → reveal only
+        val goal = goalStone("g1", setOf(Direction.LEFT, Direction.BOTTOM))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(hPathCard("h1")), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(goal)
+        )
+        val result = turnManager.playCard(p1, "h1", placePos, isRotated = false)
+        val updated = result.updatedGameState.boardPlacements.find { it.position == goalPos }!!
+        assertTrue(updated.card.isRevealed)
+        assertFalse(updated.card.isRotated)
+        assertEquals(setOf(Direction.LEFT, Direction.BOTTOM), updated.card.connections)
+    }
+
+    @Test
+    fun `playCard pathConnectsTowardGoalThatDoesNotConnectBack revealsAndRotates180`() {
+        // goal has {TOP, RIGHT} – no LEFT → goalConnects = false → reveal + rotate
+        val goal = goalStone("g1", setOf(Direction.TOP, Direction.RIGHT))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(hPathCard("h1")), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(goal)
+        )
+        val result = turnManager.playCard(p1, "h1", placePos, isRotated = false)
+        val updated = result.updatedGameState.boardPlacements.find { it.position == goalPos }!!
+        assertTrue(updated.card.isRevealed)
+        assertTrue(updated.card.isRotated)
+        assertEquals(setOf(Direction.BOTTOM, Direction.LEFT), updated.card.connections)
+    }
+
+    @Test
+    fun `playCard pathDoesNotConnectTowardGoal goalStaysHidden`() {
+        // leftOnlyCard has only LEFT – connects to start but not RIGHT toward goal
+        val goal = goalStone("g1", setOf(Direction.LEFT, Direction.BOTTOM))
+        val leftOnly = TunnelCard("lft", CardType.PATH, setOf(Direction.LEFT))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(leftOnly), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(goal)
+        )
+        val result = turnManager.playCard(p1, "lft", placePos, isRotated = false)
+        val unchanged = result.updatedGameState.boardPlacements.find { it.position == goalPos }!!
+        assertFalse(unchanged.card.isRevealed)
+    }
+
+    @Test
+    fun `playCard pathAdjacentToGoalGold revealsWithoutRotation`() {
+        // goal_gold connects all four directions → goalConnects always true → never rotated
+        turnManager.initializeGame(
+            distribution(h1 = listOf(hPathCard("h1")), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(goalGold())
+        )
+        val result = turnManager.playCard(p1, "h1", placePos, isRotated = false)
+        val updated = result.updatedGameState.boardPlacements.find { it.position == goalPos }!!
+        assertTrue(updated.card.isRevealed)
+        assertFalse(updated.card.isRotated)
+    }
+
+    @Test
+    fun `playCard pathAdjacentToAlreadyRevealedGoal doesNotReprocess`() {
+        val alreadyRevealed = TunnelCard(
+            "g1", CardType.GOAL, setOf(Direction.LEFT, Direction.BOTTOM), isRevealed = true, isGoal = false
+        )
+        turnManager.initializeGame(
+            distribution(h1 = listOf(hPathCard("h1")), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(alreadyRevealed)
+        )
+        val result = turnManager.playCard(p1, "h1", placePos, isRotated = false)
+        val unchanged = result.updatedGameState.boardPlacements.find { it.position == goalPos }!!
+        assertTrue(unchanged.card.isRevealed)
+        assertFalse(unchanged.card.isRotated)
+        assertEquals(setOf(Direction.LEFT, Direction.BOTTOM), unchanged.card.connections)
+    }
+
+    @Test
+    fun `playCard pathAdjacentToMultipleGoals revealsAll`() {
+        // goal1 to the RIGHT of placePos, goal2 BELOW – placed card connects both directions
+        val pos1 = BoardPosition(row = 4, column = 4)
+        val pos2 = BoardPosition(row = 5, column = 3)
+        val goal1 = goalStone("g1", setOf(Direction.LEFT, Direction.TOP))   // LEFT → goalConnects RIGHT side
+        val goal2 = goalStone("g2", setOf(Direction.TOP, Direction.RIGHT))  // TOP → goalConnects BOTTOM side
+        val boardState = GameState(
+            players = listOf(PlayerTurn(p1, "Alice", 1), PlayerTurn(p2, "Bob", 2), PlayerTurn(p3, "Charlie", 3)),
+            currentPlayerId = p1,
+            boardPlacements = listOf(
+                PlacedTunnelCard(startPosition, startCard),
+                PlacedTunnelCard(pos1, goal1),
+                PlacedTunnelCard(pos2, goal2)
+            )
+        )
+        val multiCard = TunnelCard("mc", CardType.PATH, setOf(Direction.LEFT, Direction.RIGHT, Direction.BOTTOM))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(multiCard), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            boardState
+        )
+        val result = turnManager.playCard(p1, "mc", placePos, isRotated = false)
+        assertTrue(result.updatedGameState.boardPlacements.find { it.position == pos1 }!!.card.isRevealed)
+        assertTrue(result.updatedGameState.boardPlacements.find { it.position == pos2 }!!.card.isRevealed)
+    }
+
+    @Test
+    fun `playCard deadEndAdjacentToGoal doesNotRevealGoal`() {
+        val goal = goalStone("g1", setOf(Direction.LEFT, Direction.BOTTOM))
+        val deadEnd = TunnelCard("de1", CardType.DEAD_END, setOf(Direction.LEFT, Direction.RIGHT))
+        turnManager.initializeGame(
+            distribution(h1 = listOf(deadEnd), h2 = listOf(pathCard("c2")), h3 = listOf(pathCard("c3"))),
+            stateWithGoal(goal)
+        )
+        val result = turnManager.playCard(p1, "de1", placePos, isRotated = false)
+        assertFalse(result.updatedGameState.boardPlacements.find { it.position == goalPos }!!.card.isRevealed)
+    }
+
     @Test
     fun `nextPlayerId unknownCurrentPlayer fallsBackToFirst`() {
         val ghost = "ghost"

--- a/server/src/test/kotlin/com/aau/server/WebSocketHandlerTests.kt
+++ b/server/src/test/kotlin/com/aau/server/WebSocketHandlerTests.kt
@@ -6,6 +6,7 @@ import com.aau.server.model.GameStartResult
 import com.aau.server.service.GameService
 import com.aau.server.service.LobbyService
 import com.aau.server.service.MessagingService
+import com.aau.server.service.TurnManager
 import com.aau.server.websocket.WebSocketHandler
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -27,6 +28,7 @@ class WebSocketHandlerTests {
     private lateinit var gameService: GameService
     private lateinit var lobbyService: LobbyService
     private lateinit var messagingService: MessagingService
+    private lateinit var turnManager: TurnManager
     private lateinit var objectMapper: ObjectMapper
     private lateinit var handler: WebSocketHandler
     private lateinit var session: WebSocketSession
@@ -36,9 +38,10 @@ class WebSocketHandlerTests {
         gameService = mock(GameService::class.java)
         lobbyService = mock(LobbyService::class.java)
         messagingService = mock(MessagingService::class.java)
+        turnManager = mock(TurnManager::class.java)
         objectMapper = jacksonObjectMapper()
 
-        handler = WebSocketHandler(objectMapper, gameService, messagingService, lobbyService)
+        handler = WebSocketHandler(objectMapper, gameService, messagingService, lobbyService, turnManager)
 
         session = mock(WebSocketSession::class.java)
         `when`(session.isOpen).thenReturn(true)
@@ -298,7 +301,7 @@ class WebSocketHandlerTests {
     @Test
     fun `handleTextMessage handles exception without message`() {
         val mockMapper = mock(ObjectMapper::class.java)
-        val handlerWithMock = WebSocketHandler(mockMapper, gameService, messagingService, lobbyService)
+        val handlerWithMock = WebSocketHandler(mockMapper, gameService, messagingService, lobbyService, turnManager)
 
         `when`(mockMapper.readTree(anyString())).thenThrow(RuntimeException())
         `when`(mockMapper.writeValueAsString(any())).thenReturn("{\"type\":\"ERROR\",\"data\":\"Unknown error\"}")

--- a/server/src/test/kotlin/com/aau/server/WebSocketHandlerTests.kt
+++ b/server/src/test/kotlin/com/aau/server/WebSocketHandlerTests.kt
@@ -3,6 +3,8 @@ package com.aau.server
 import com.aau.saboteur.model.*
 import com.aau.server.model.CardDistributionResult
 import com.aau.server.model.GameStartResult
+import com.aau.server.model.TurnResult
+import org.mockito.ArgumentMatchers.anyBoolean
 import com.aau.server.service.GameService
 import com.aau.server.service.LobbyService
 import com.aau.server.service.MessagingService
@@ -333,5 +335,195 @@ class WebSocketHandlerTests {
         handler.handleTextMessage(session, message)
 
         verify(session, atLeastOnce()).sendMessage(anyK())
+    }
+
+    // ── PLAY_CARD handling ───────────────────────────────────────────────────
+
+    @Test
+    fun `handleTextMessage PLAY_CARD broadcasts GAME_STATE_UPDATE and CARDS_DEALT`() {
+        val request = PlayCardRequest("1", "card1", BoardPosition(3, 2), false)
+        val message = TextMessage(objectMapper.writeValueAsString(mapOf("type" to "PLAY_CARD", "data" to request)))
+
+        `when`(messagingService.getLobbyCodeForSession(anyString())).thenReturn("1234")
+        `when`(messagingService.getPlayerIdForSession(anyString())).thenReturn("1")
+
+        val newState = GameState(listOf(PlayerTurn("1", "Alice", 1), PlayerTurn("2", "Bob", 2)), "2")
+        val newHands = mapOf<String, List<TunnelCard>>("1" to emptyList(), "2" to listOf(createDummyCard()))
+        val turnResult = TurnResult(newState, newHands)
+
+        `when`(turnManager.playCard(anyString(), anyString(), anyK(), anyBoolean())).thenReturn(turnResult)
+
+        handler.handleTextMessage(session, message)
+
+        verify(turnManager).playCard(eqK("1"), eqK("card1"), eqK(BoardPosition(3, 2)), eqK(false))
+        verify(messagingService).broadcastToLobby(eqK("1234"), eqK("GAME_STATE_UPDATE"), eqK(newState))
+        verify(messagingService).broadcastToLobby(eqK("1234"), eqK("CARDS_DEALT"), eqK(newHands))
+    }
+
+    @Test
+    fun `handleTextMessage PLAY_CARD throws when session not in lobby`() {
+        val request = PlayCardRequest("1", "card1", BoardPosition(3, 2), false)
+        val message = TextMessage(objectMapper.writeValueAsString(mapOf("type" to "PLAY_CARD", "data" to request)))
+
+        `when`(messagingService.getLobbyCodeForSession(anyString())).thenReturn(null)
+
+        handler.handleTextMessage(session, message)
+
+        val captor = ArgumentCaptor.forClass(TextMessage::class.java)
+        verify(session).sendMessage(captor.capture())
+        assertTrue(captor.value.payload.contains("Session is not connected to a lobby"))
+    }
+
+    @Test
+    fun `handleTextMessage PLAY_CARD throws when player not registered`() {
+        val request = PlayCardRequest("1", "card1", BoardPosition(3, 2), false)
+        val message = TextMessage(objectMapper.writeValueAsString(mapOf("type" to "PLAY_CARD", "data" to request)))
+
+        `when`(messagingService.getLobbyCodeForSession(anyString())).thenReturn("1234")
+        `when`(messagingService.getPlayerIdForSession(anyString())).thenReturn(null)
+
+        handler.handleTextMessage(session, message)
+
+        val captor = ArgumentCaptor.forClass(TextMessage::class.java)
+        verify(session).sendMessage(captor.capture())
+        assertTrue(captor.value.payload.contains("Session is not linked to a player"))
+    }
+
+    @Test
+    fun `handleTextMessage PLAY_CARD throws when player ID mismatch`() {
+        val request = PlayCardRequest("1", "card1", BoardPosition(3, 2), false)
+        val message = TextMessage(objectMapper.writeValueAsString(mapOf("type" to "PLAY_CARD", "data" to request)))
+
+        `when`(messagingService.getLobbyCodeForSession(anyString())).thenReturn("1234")
+        `when`(messagingService.getPlayerIdForSession(anyString())).thenReturn("2") // differs from request.playerId
+
+        handler.handleTextMessage(session, message)
+
+        val captor = ArgumentCaptor.forClass(TextMessage::class.java)
+        verify(session).sendMessage(captor.capture())
+        assertTrue(captor.value.payload.contains("Player ID mismatch"))
+    }
+
+    // ── DISCARD_CARD handling ────────────────────────────────────────────────
+
+    @Test
+    fun `handleTextMessage DISCARD_CARD broadcasts GAME_STATE_UPDATE and CARDS_DEALT`() {
+        val request = DiscardCardRequest("1", "card1")
+        val message = TextMessage(objectMapper.writeValueAsString(mapOf("type" to "DISCARD_CARD", "data" to request)))
+
+        `when`(messagingService.getLobbyCodeForSession(anyString())).thenReturn("1234")
+        `when`(messagingService.getPlayerIdForSession(anyString())).thenReturn("1")
+
+        val newState = GameState(listOf(PlayerTurn("1", "Alice", 1), PlayerTurn("2", "Bob", 2)), "2")
+        val newHands = mapOf<String, List<TunnelCard>>("1" to emptyList(), "2" to listOf(createDummyCard()))
+        val turnResult = TurnResult(newState, newHands)
+
+        `when`(turnManager.discardCard(anyString(), anyString())).thenReturn(turnResult)
+
+        handler.handleTextMessage(session, message)
+
+        verify(turnManager).discardCard(eqK("1"), eqK("card1"))
+        verify(messagingService).broadcastToLobby(eqK("1234"), eqK("GAME_STATE_UPDATE"), eqK(newState))
+        verify(messagingService).broadcastToLobby(eqK("1234"), eqK("CARDS_DEALT"), eqK(newHands))
+    }
+
+    @Test
+    fun `handleTextMessage DISCARD_CARD throws when session not in lobby`() {
+        val request = DiscardCardRequest("1", "card1")
+        val message = TextMessage(objectMapper.writeValueAsString(mapOf("type" to "DISCARD_CARD", "data" to request)))
+
+        `when`(messagingService.getLobbyCodeForSession(anyString())).thenReturn(null)
+
+        handler.handleTextMessage(session, message)
+
+        val captor = ArgumentCaptor.forClass(TextMessage::class.java)
+        verify(session).sendMessage(captor.capture())
+        assertTrue(captor.value.payload.contains("Session is not connected to a lobby"))
+    }
+
+    @Test
+    fun `handleTextMessage DISCARD_CARD throws when player not registered`() {
+        val request = DiscardCardRequest("1", "card1")
+        val message = TextMessage(objectMapper.writeValueAsString(mapOf("type" to "DISCARD_CARD", "data" to request)))
+
+        `when`(messagingService.getLobbyCodeForSession(anyString())).thenReturn("1234")
+        `when`(messagingService.getPlayerIdForSession(anyString())).thenReturn(null)
+
+        handler.handleTextMessage(session, message)
+
+        val captor = ArgumentCaptor.forClass(TextMessage::class.java)
+        verify(session).sendMessage(captor.capture())
+        assertTrue(captor.value.payload.contains("Session is not linked to a player"))
+    }
+
+    @Test
+    fun `handleTextMessage DISCARD_CARD throws when player ID mismatch`() {
+        val request = DiscardCardRequest("1", "card1")
+        val message = TextMessage(objectMapper.writeValueAsString(mapOf("type" to "DISCARD_CARD", "data" to request)))
+
+        `when`(messagingService.getLobbyCodeForSession(anyString())).thenReturn("1234")
+        `when`(messagingService.getPlayerIdForSession(anyString())).thenReturn("2")
+
+        handler.handleTextMessage(session, message)
+
+        val captor = ArgumentCaptor.forClass(TextMessage::class.java)
+        verify(session).sendMessage(captor.capture())
+        assertTrue(captor.value.payload.contains("Player ID mismatch"))
+    }
+
+    // ── START_GAME: playerRoles forEach ─────────────────────────────────────
+
+    @Test
+    fun `handleTextMessage START_GAME sends PLAYER_DATA to each player`() {
+        val players = listOf(Player("1", "Alice"), Player("2", "Bob"), Player("3", "Charlie"))
+        val request = CreateGameRequest(players = players)
+        val message = TextMessage(objectMapper.writeValueAsString(mapOf("type" to "START_GAME", "data" to request)))
+
+        val lobbyCode = "1234"
+        val hostId = "1"
+        val lobbyState = LobbyState(lobbyCode, hostId, players)
+
+        `when`(messagingService.getLobbyCodeForSession(anyString())).thenReturn(lobbyCode)
+        `when`(messagingService.getPlayerIdForSession(anyString())).thenReturn(hostId)
+        `when`(lobbyService.getLobby(anyString())).thenReturn(lobbyState)
+
+        val newState = GameState(
+            players = listOf(PlayerTurn("1", "Alice", 1), PlayerTurn("2", "Bob", 2), PlayerTurn("3", "Charlie", 3)),
+            currentPlayerId = "1"
+        )
+        val alice = Player("1", "Alice")
+        val bob   = Player("2", "Bob")
+        val charlie = Player("3", "Charlie")
+        val startResult = GameStartResult(
+            gameState = newState,
+            playerRoles = mapOf("1" to alice, "2" to bob, "3" to charlie),
+            cardDistribution = CardDistributionResult(emptyMap(), emptyList(), emptyList(), createDummyCard())
+        )
+
+        `when`(gameService.startGame(anyList())).thenReturn(startResult)
+        `when`(lobbyService.markGameStarted(anyString())).thenReturn(lobbyState.copy(gameStarted = true))
+
+        handler.handleTextMessage(session, message)
+
+        verify(messagingService).sendToPlayer(eqK("1"), eqK("PLAYER_DATA"), eqK(alice))
+        verify(messagingService).sendToPlayer(eqK("2"), eqK("PLAYER_DATA"), eqK(bob))
+        verify(messagingService).sendToPlayer(eqK("3"), eqK("PLAYER_DATA"), eqK(charlie))
+    }
+
+    // ── LOBBY_LEAVE: last player (null response) ─────────────────────────────
+
+    @Test
+    fun `handleTextMessage LOBBY_LEAVE when last player leaves does not broadcast state update`() {
+        val request = LobbyLeaveRequest(lobbyCode = "1234", playerId = "1")
+        val message = TextMessage(objectMapper.writeValueAsString(mapOf("type" to "LOBBY_LEAVE", "data" to request)))
+
+        `when`(lobbyService.leaveLobby(anyString(), anyString())).thenReturn(null)
+
+        handler.handleTextMessage(session, message)
+
+        verify(messagingService).leaveLobbyGroup("test-session", "1234")
+        verify(messagingService).sendToSession(eqK("test-session"), eqK("LOBBY_LEFT"), anyK())
+        verify(messagingService, never()).broadcastToLobby(anyString(), eqK("LOBBY_STATE_UPDATE"), anyK())
+        verify(messagingService).broadcast(eqK("LOBBY_LIST_UPDATE"), anyK())
     }
 }

--- a/shared/src/commonMain/kotlin/com/aau/saboteur/model/TunnelCard.kt
+++ b/shared/src/commonMain/kotlin/com/aau/saboteur/model/TunnelCard.kt
@@ -5,8 +5,12 @@ import kotlinx.serialization.Serializable
 data class TunnelCard(
     val id: String,
     val type: CardType,
+    // Always stores effective (post-rotation) values. Placement logic reads
+    // connections directly and never re-applies isRotated.
     val connections: Set<Direction>,
     val isRevealed: Boolean = false,
     val isGoal: Boolean = false,
+    // Render-only flag. The UI draws the card rotated 180°; connections already
+    // reflect the post-rotation state and must not be flipped again on read.
     val isRotated: Boolean = false
 )

--- a/shared/src/commonMain/kotlin/com/aau/saboteur/model/TurnMessages.kt
+++ b/shared/src/commonMain/kotlin/com/aau/saboteur/model/TurnMessages.kt
@@ -1,0 +1,17 @@
+package com.aau.saboteur.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PlayCardRequest(
+    val playerId: String,
+    val cardId: String,
+    val position: BoardPosition,
+    val isRotated: Boolean = false
+)
+
+@Serializable
+data class DiscardCardRequest(
+    val playerId: String,
+    val cardId: String
+)


### PR DESCRIPTION
## Zusammenfassung

  Vollständige Implementierung der Kartenlege-Logik und des Spielerwechsels —
  von der Server-Spiellogik über die App-UI bis hin zu den Zielkarten.

  ---

  ## Änderungen

  ### Server – Spiellogik

  - **Turn-Logik:** Karte legen (`playCard`), Karte abwerfen (`discardCard`),
    Nachziehen vom Stapel, automatischer Spielerwechsel nach jeder Aktion
  - **Platzierungsvalidierung:** XOR-Adjacency-Regel (offenes Tunnel-Ende ungültig),
    BFS-Erreichbarkeitsprüfung vom START-Feld aus
  - **Aktionskarten-Sperre:** Aktionskarten können nicht auf das Spielfeld gelegt werden
  - **Hilfsfunktion `buildGrid()`:** Grid wird pro Zug nur einmal aufgebaut;
    `canPlaceOnBoard` und `isReachableFromStart` teilen dieselbe Map-Instanz
  von der Server-Spiellogik über die App-UI bis hin zu den Zielkarten.

  ---

  ## Änderungen

  ### Server – Spiellogik

  - **Turn-Logik:** Karte legen (`playCard`), Karte abwerfen (`discardCard`),
    Nachziehen vom Stapel, automatischer Spielerwechsel nach jeder Aktion
  - **Platzierungsvalidierung:** XOR-Adjacency-Regel (offenes Tunnel-Ende ungültig),
    BFS-Erreichbarkeitsprüfung vom START-Feld aus
  - **Aktionskarten-Sperre:** Aktionskarten können nicht auf das Spielfeld gelegt werden
  - **Hilfsfunktion `buildGrid()`:** Grid wird pro Zug nur einmal aufgebaut;
    `canPlaceOnBoard` und `isReachableFromStart` teilen dieselbe Map-Instanz
  - **Fehlermeldungen:** Alle `require`/`throw`-Meldungen auf Deutsch

  ### Server – Zielkarten

  - **Aufdecklogik:** Zielkarten werden aufgedeckt, sobald eine PATH-Karte auf sie zeigt
  - **Auto-Rotation:** Stein-Zielkarten werden beim Aufdecken um 180° gedreht,
    wenn die Tunnelverbindung nicht zurückzeigt; `goal_gold` wird nie gedreht
  - **Adjacency-Fix:** XOR-Prüfung wird für verdeckte Zielkarten übersprungen
  - **Reachability-Fix:** Aufgedeckte Zielkarten sind traversierbare BFS-Knoten —
    Felder hinter ihnen waren zuvor fälschlicherweise unerreichbar

  ### Server – `GameBoard`

  - BFS-Erreichbarkeitsprüfung korrigiert: traversiert jetzt auch aufgedeckte
    GOAL-Karten (identische Logik wie `TurnManager`)

  ### App – UI & Interaktion

  - **Karte auswählen & legen:** Antippen wählt eine Karte aus der Hand,
    Antippen eines Feldes legt sie dort ab
  - **Drehen per Doppeltipp:** ersetzt den alten Rotate-Button;
    Rotation betrifft nur das Kartenbild, nicht den Auswahlrahmen
  - **Abwerfen:** Ausgewählte Karte kann über den Abwerfen-Button entfernt werden
  - **Fehlerfeedback:** Serverfehlermeldungen erscheinen und blenden sich
    nach 2 Sekunden aus; Karte bleibt bei Ablehnung ausgewählt
  - **Rendering:** Korrekte Asset-Auswahl für gedrehte Karten via
    `toCanonicalDrawableName()` + `Modifier.rotate(180f)`
  - **String-Ressourcen:** Alle UI-Texte als `stringResource`-Einträge in
    `strings.xml` — kein hartkodiertes Englisch mehr

  ---

  ## Tests

  - Unit-Tests für `TurnManager` mit ≥ 94 % Branch-Coverage
  - Tests für bidirektionale Konnektivität, Aktionskarten, Rotation und Erreichbarkeit
  - Tests für Zielkarten-Aufdeckung, Auto-Rotation und Erreichbarkeit durch
    aufgedeckte Zielkarten
  - Neue `GameBoard`-Tests: aufgedeckte GOAL-Karte traversierbar,
    verdeckte GOAL-Karte nicht traversierbar

  ---

  ## Testplan

  - [ ] Alle bestehenden Server-Tests bestehen (`./gradlew :server:test`)
  - [ ] Karte antippen → auswählen; Feld antippen → legen
  - [ ] Doppeltipp dreht Karte; gedrehte Karte wird korrekt dargestellt
  - [ ] Ungültige Platzierung zeigt deutschen Fehlerhinweis
  - [ ] Aktionskarten können nicht gelegt werden
  - [ ] Spielerwechsel nach jeder Aktion korrekt
  - [ ] Zielkarten starten verdeckt; werden beim ersten Tunnel-Kontakt aufgedeckt
  - [ ] Stein-Zielkarten drehen sich bei Mismatch automatisch
  - [ ] Karten können hinter aufgedeckten Zielkarten platziert werden