### PR TITLE
Feature: Spezialkarten-Ende-zu-Ende-Unterstützung im Client (Block/Repair/Map/Rockfall) [refs #98]

### DIFF
--- a/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
+++ b/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
@@ -6,12 +6,7 @@ import com.aau.saboteur.network.lobby.LobbyApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import org.json.JSONObject
 
@@ -56,7 +51,6 @@ object GameApi {
             runCatching { data.toPlayer() }
                 .onSuccess { player ->
                     _playerUpdates.value = player
-                    // Sync hands if available in player data
                     if (player.hand.isNotEmpty()) {
                         val currentHands = _cardsDealtUpdates.value ?: emptyMap()
                         _cardsDealtUpdates.value = currentHands + (player.id to player.hand)
@@ -89,10 +83,10 @@ object GameApi {
                     _reconnectSnapshotEvents.tryEmit(snapshot)
                     _gameStateUpdates.value = snapshot.gameState ?: GameState()
                     _playerUpdates.value = snapshot.playerState
-                    
+
                     val currentHands = _cardsDealtUpdates.value ?: emptyMap()
                     _cardsDealtUpdates.value = currentHands + (snapshot.playerState.id to snapshot.playerState.hand)
-                    
+
                     WebSocketManager.sendCommand("SYNC_ACK", JSONObject())
                 }
                 .onFailure { it.printStackTrace() }
@@ -115,46 +109,96 @@ object GameApi {
         scope.launch {
             LobbyApi.reconnectData.collect { data ->
                 val existingPlayer = data.lobbyState.players.find { it.id == data.myPlayerId }
-                
+
                 data.gameState?.let {
                     _gameStateUpdates.value = it
                 }
-                
+
                 _playerUpdates.value = Player(
                     id = data.myPlayerId,
                     name = existingPlayer?.name ?: "",
                     hand = data.playerHand,
                     role = data.playerRole ?: existingPlayer?.role
                 )
-                
-                // CRITICAL: Always update hands from HTTP response
+
                 val currentHands = _cardsDealtUpdates.value ?: emptyMap()
                 _cardsDealtUpdates.value = currentHands + (data.myPlayerId to data.playerHand)
             }
         }
     }
 
-    fun startGame(players: List<Player>) {
+    fun startGame(lobbyCode: String, players: List<Player>) {
         val request = CreateGameRequest(players = players)
-        WebSocketManager.sendCommand("START_GAME", JSONObject(request.toJson()))
+        val payload = JSONObject(request.toJson()).apply {
+            put("lobbyCode", lobbyCode)
+        }
+        WebSocketManager.sendCommand("START_GAME", payload)
     }
 
-    fun playCard(playerId: String, cardId: String, position: BoardPosition, isRotated: Boolean) {
+    fun playCard(lobbyCode: String, playerId: String, cardId: String, position: BoardPosition, isRotated: Boolean) {
         val request = PlayCardRequest(playerId, cardId, position, isRotated)
-        WebSocketManager.sendCommand("PLAY_CARD", JSONObject(request.toJson()))
+        val payload = JSONObject(request.toJson()).apply {
+            put("lobbyCode", lobbyCode)
+        }
+        WebSocketManager.sendCommand("PLAY_CARD", payload)
     }
 
-    fun discardCard(playerId: String, cardId: String) {
+    fun discardCard(lobbyCode: String, playerId: String, cardId: String) {
         val request = DiscardCardRequest(playerId, cardId)
-        WebSocketManager.sendCommand("DISCARD_CARD", JSONObject(request.toJson()))
+        val payload = JSONObject(request.toJson()).apply {
+            put("lobbyCode", lobbyCode)
+        }
+        WebSocketManager.sendCommand("DISCARD_CARD", payload)
     }
 
-    fun requestValidPositions(cardId: String, isRotated: Boolean) {
+    fun requestValidPositions(lobbyCode: String, cardId: String, isRotated: Boolean) {
         val payload = JSONObject().apply {
             put("cardId", cardId)
             put("isRotated", isRotated)
+            put("lobbyCode", lobbyCode)
         }
         WebSocketManager.sendCommand("GET_VALID_POSITIONS", payload)
+    }
+
+    fun playBlockCard(lobbyCode: String, playerId: String, cardId: String, targetPlayerId: String) {
+        val payload = JSONObject().apply {
+            put("lobbyCode", lobbyCode)
+            put("playerId", playerId)
+            put("cardId", cardId)
+            put("targetPlayerId", targetPlayerId)
+        }
+        WebSocketManager.sendCommand("PLAY_BLOCK_CARD", payload)
+    }
+
+    fun playRepairCard(lobbyCode: String, playerId: String, cardId: String, targetPlayerId: String, tool: String) {
+        val payload = JSONObject().apply {
+            put("lobbyCode", lobbyCode)
+            put("playerId", playerId)
+            put("cardId", cardId)
+            put("targetPlayerId", targetPlayerId)
+            put("tool", tool)
+        }
+        WebSocketManager.sendCommand("PLAY_REPAIR_CARD", payload)
+    }
+
+    fun playMapCard(lobbyCode: String, playerId: String, cardId: String, position: BoardPosition) {
+        val payload = JSONObject().apply {
+            put("lobbyCode", lobbyCode)
+            put("playerId", playerId)
+            put("cardId", cardId)
+            put("position", position)
+        }
+        WebSocketManager.sendCommand("PLAY_MAP_CARD", payload)
+    }
+
+    fun playRockfallCard(lobbyCode: String, playerId: String, cardId: String, position: BoardPosition) {
+        val payload = JSONObject().apply {
+            put("lobbyCode", lobbyCode)
+            put("playerId", playerId)
+            put("cardId", cardId)
+            put("position", position)
+        }
+        WebSocketManager.sendCommand("PLAY_ROCKFALL_CARD", payload)
     }
 
     internal fun clearValidPositions() {
@@ -166,6 +210,5 @@ object GameApi {
         _playerUpdates.value = null
         _cardsDealtUpdates.value = null
         _validPositionsUpdates.tryEmit(emptyList())
-        // Reset flows by not emitting anything or emitting defaults
     }
 }

--- a/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
+++ b/app/app/src/main/java/com/aau/saboteur/network/game/GameApi.kt
@@ -9,6 +9,13 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import org.json.JSONObject
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+data class MapResult(
+    val position: BoardPosition,
+    val card: TunnelCard
+)
 
 object GameApi {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -33,6 +40,9 @@ object GameApi {
 
     private val _reconnectSnapshotEvents = MutableSharedFlow<ReconnectSnapshot>(replay = 1)
     val reconnectSnapshotEvents: SharedFlow<ReconnectSnapshot> = _reconnectSnapshotEvents.asSharedFlow()
+
+    private val _mapResultEvents = MutableSharedFlow<MapResult>(replay = 0, extraBufferCapacity = 1)
+    val mapResultEvents: SharedFlow<MapResult> = _mapResultEvents.asSharedFlow()
 
     init {
         observeEvents()
@@ -94,6 +104,12 @@ object GameApi {
 
         WebSocketManager.onEvent("ERROR") { data ->
             _errorMessages.tryEmit(data)
+        }
+
+        WebSocketManager.onEvent("MAP_RESULT") { data ->
+            runCatching { data.toMapResult() }
+                .onSuccess { _mapResultEvents.tryEmit(it) }
+                .onFailure { it.printStackTrace() }
         }
     }
 
@@ -186,7 +202,10 @@ object GameApi {
             put("lobbyCode", lobbyCode)
             put("playerId", playerId)
             put("cardId", cardId)
-            put("position", position)
+            put("targetPosition", JSONObject().apply {
+                put("row", position.row)
+                put("column", position.column)
+            })
         }
         WebSocketManager.sendCommand("PLAY_MAP_CARD", payload)
     }
@@ -196,7 +215,10 @@ object GameApi {
             put("lobbyCode", lobbyCode)
             put("playerId", playerId)
             put("cardId", cardId)
-            put("position", position)
+            put("targetPosition", JSONObject().apply {
+                put("row", position.row)
+                put("column", position.column)
+            })
         }
         WebSocketManager.sendCommand("PLAY_ROCKFALL_CARD", payload)
     }
@@ -210,5 +232,15 @@ object GameApi {
         _playerUpdates.value = null
         _cardsDealtUpdates.value = null
         _validPositionsUpdates.tryEmit(emptyList())
+    }
+
+    private fun String.toMapResult(): MapResult {
+        val json = JSONObject(this)
+        val posJson = json.getJSONObject("position")
+        val cardJson = json.getJSONObject("card")
+        return MapResult(
+            position = BoardPosition(posJson.getInt("row"), posJson.getInt("column")),
+            card = Json.decodeFromString<TunnelCard>(cardJson.toString())
+        )
     }
 }

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/PlayerCard.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/PlayerCard.kt
@@ -5,6 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -44,6 +47,11 @@ fun PlayerCard(
             colors = listOf(MineCoal, MineSlate)
         )
     }
+    val toolEmojis = buildString {
+        if (player.blockedTools.any { it.name == "PICKAXE" }) append("⛏️")
+        if (player.blockedTools.any { it.name == "LANTERN" }) append("🏮")
+        if (player.blockedTools.any { it.name == "CART" }) append("🛒")
+    }
 
     Card(
         modifier = modifier.then(
@@ -79,12 +87,22 @@ fun PlayerCard(
                 modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Text(
-                    text = player.playerName,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.SemiBold,
-                    color = if (isCurrentPlayer) MineCoal else Quartz
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = player.playerName,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = if (isCurrentPlayer) MineCoal else Quartz
+                    )
+                    if (toolEmojis.isNotEmpty()) {
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = toolEmojis,
+                            color = if (isCurrentPlayer) MineCoal else Quartz,
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -9,23 +9,44 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.aau.saboteur.model.*
 import com.aau.saboteur.ui.components.*
 import com.aau.saboteur.viewModels.GameViewModel
 import com.aau.saboteur.viewModels.LobbyViewModel
-import kotlinx.coroutines.delay
+
+private fun isToolBlocked(blockedTools: Set<ToolType>, tool: String): Boolean {
+    return blockedTools.any { it.name == tool }
+}
 
 private fun isBlockCard(type: CardType) =
     type == CardType.CART_RED || type == CardType.LANTERN_RED || type == CardType.PICKAXE_RED
 
 private fun isRepairCard(type: CardType) =
-    type == CardType.CART_GREEN || type == CardType.LANTERN_GREEN || type == CardType.PICKAXE_GREEN ||
-            type == CardType.DOUBLE_LANTERN_CART || type == CardType.DOUBLE_PICKAXE_CART || type == CardType.DOUBLE_PICKAXE_LANTERN
+    type == CardType.CART_GREEN || type == CardType.LANTERN_GREEN || type == CardType.PICKAXE_GREEN
+            || type == CardType.DOUBLE_LANTERN_CART || type == CardType.DOUBLE_PICKAXE_CART || type == CardType.DOUBLE_PICKAXE_LANTERN
 
 private fun needsTargetDialog(type: CardType) = isBlockCard(type) || isRepairCard(type)
+
+private fun getRepairToolsFromCard(type: CardType): List<String> = when(type) {
+    CardType.LANTERN_GREEN -> listOf("LANTERN")
+    CardType.PICKAXE_GREEN -> listOf("PICKAXE")
+    CardType.CART_GREEN -> listOf("CART")
+    CardType.DOUBLE_LANTERN_CART -> listOf("LANTERN", "CART")
+    CardType.DOUBLE_PICKAXE_CART -> listOf("PICKAXE", "CART")
+    CardType.DOUBLE_PICKAXE_LANTERN -> listOf("PICKAXE", "LANTERN")
+    else -> emptyList()
+}
+
+@Composable
+private fun ToolIcons(blockedTools: Set<ToolType>) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        if (blockedTools.any { it.name == "PICKAXE" }) Text("⛏️")
+        if (blockedTools.any { it.name == "LANTERN" }) Text("🏮")
+        if (blockedTools.any { it.name == "CART" }) Text("🛒")
+    }
+}
 
 @Composable
 fun GameScreen(
@@ -38,16 +59,14 @@ fun GameScreen(
     val lobbyState by lobbyViewModel.lobbyState.collectAsState()
     val lobbyCode = lobbyState?.lobbyCode
     val validPositions by viewModel.validPositions.collectAsState()
-
     var gameOverWinner by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) {
         viewModel.gameOverEvents.collect { winner -> gameOverWinner = winner }
     }
-
     LaunchedEffect(localPlayerId, lobbyCode) {
         if (localPlayerId != null && lobbyCode != null) {
-            viewModel.initGameSession(lobbyCode!!, localPlayerId!!)
+            viewModel.initGameSession(lobbyCode, localPlayerId!!)
         }
     }
 
@@ -58,6 +77,8 @@ fun GameScreen(
             !uiState.isSyncing
 
     var showBlockDialog by remember { mutableStateOf(false) }
+    var showToolDialog by remember { mutableStateOf(false) }
+    var pendingToolSelection by remember { mutableStateOf<Pair<String, List<String>>?>(null) }
 
     Box(
         modifier = Modifier
@@ -74,7 +95,6 @@ fun GameScreen(
                 }
             }
         )
-
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -102,13 +122,11 @@ fun GameScreen(
                 }
             }
         }
-
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
                 .padding(horizontal = 32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             uiState.errorMessage?.let {
                 Surface(
@@ -125,7 +143,6 @@ fun GameScreen(
                 }
             }
         }
-
         if (currentHand != null) {
             Column(
                 modifier = Modifier
@@ -146,7 +163,6 @@ fun GameScreen(
                 uiState.player?.role?.let { role ->
                     RoleCardView(role = role, compact = true)
                 }
-
                 if (isMyTurn && uiState.selectedCard != null) {
                     Button(
                         onClick = { viewModel.discardSelectedCard() },
@@ -155,7 +171,6 @@ fun GameScreen(
                         Text("Karte verwerfen", color = MaterialTheme.colorScheme.onErrorContainer)
                     }
                 }
-
                 PlayerHandRow(
                     hand = currentHand,
                     selectedCardId = uiState.selectedCard?.id,
@@ -169,11 +184,9 @@ fun GameScreen(
                 )
             }
         }
-
         gameOverWinner?.let { winner ->
             GameOverDialog(winner = winner, onBackToLobby = onBackToLobby)
         }
-
         if (uiState.isSyncing) {
             GameSyncOverlay()
         }
@@ -186,21 +199,48 @@ fun GameScreen(
                 onPlayerSelected = { targetId ->
                     if (isBlockCard(selected.type)) {
                         viewModel.playBlockCardOnPlayer(targetId)
+                        showBlockDialog = false
                     } else if (isRepairCard(selected.type)) {
-                        val tool = when (selected.type) {
-                            CardType.LANTERN_GREEN -> "LANTERN"
-                            CardType.PICKAXE_GREEN -> "PICKAXE"
-                            CardType.CART_GREEN -> "CART"
-                            CardType.DOUBLE_LANTERN_CART -> "LANTERN"
-                            CardType.DOUBLE_PICKAXE_CART -> "PICKAXE"
-                            CardType.DOUBLE_PICKAXE_LANTERN -> "PICKAXE"
-                            else -> "LANTERN"
+                        val repairTools = getRepairToolsFromCard(selected.type)
+                        val player = uiState.gameState.players.find { it.playerId == targetId }
+                        if (player != null) {
+                            val blocked = repairTools.filter { tool -> isToolBlocked(player.blockedTools, tool) }
+                            when (blocked.size) {
+                                0 -> {
+                                    viewModel.playRepairCardOnPlayer(targetId, repairTools.first())
+                                    showBlockDialog = false
+                                }
+                                1 -> {
+                                    viewModel.playRepairCardOnPlayer(targetId, blocked.first())
+                                    showBlockDialog = false
+                                }
+                                else -> {
+                                    pendingToolSelection = Pair(targetId, blocked)
+                                    showToolDialog = true
+                                    showBlockDialog = false
+                                }
+                            }
+                        } else {
+                            showBlockDialog = false
                         }
-                        viewModel.playRepairCardOnPlayer(targetId, tool)
                     }
-                    showBlockDialog = false
                 },
                 onDismiss = { showBlockDialog = false }
+            )
+        }
+        if (showToolDialog && pendingToolSelection != null) {
+            val (targetId, tools) = pendingToolSelection!!
+            DoubleRepairToolDialog(
+                tools = tools,
+                onToolSelected = { tool ->
+                    viewModel.playRepairCardOnPlayer(targetId, tool)
+                    showToolDialog = false
+                    pendingToolSelection = null
+                },
+                onDismiss = {
+                    showToolDialog = false
+                    pendingToolSelection = null
+                }
             )
         }
     }
@@ -218,24 +258,58 @@ fun BlockTargetDialog(
         title = { Text("Wähle einen Spieler") },
         text = {
             Column {
-                playerList
-                    .filter { it.playerId != selfPlayerId }
-                    .forEach { player ->
-                        Button(
-                            onClick = { onPlayerSelected(player.playerId) },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 4.dp)
-                        ) {
-                            Text(player.playerName)
-                        }
+                playerList.forEach { player ->
+                    val label = if (player.playerId == selfPlayerId)
+                        "${player.playerName} (Ich)"
+                    else
+                        player.playerName
+                    Button(
+                        onClick = { onPlayerSelected(player.playerId) },
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                    ) {
+                        ToolIcons(player.blockedTools)
+                        Spacer(Modifier.width(8.dp))
+                        Text(label)
                     }
+                }
             }
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text("Abbrechen")
+            TextButton(onClick = onDismiss) { Text("Abbrechen") }
+        }
+    )
+}
+
+@Composable
+fun DoubleRepairToolDialog(
+    tools: List<String>,
+    onToolSelected: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Welches Werkzeug reparieren?") },
+        text = {
+            Column {
+                tools.forEach { tool ->
+                    Button(
+                        onClick = { onToolSelected(tool) },
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                    ) {
+                        Text(
+                            when(tool) {
+                                "LANTERN" -> "Lampe reparieren 🏮"
+                                "PICKAXE" -> "Spitzhacke reparieren ⛏️"
+                                "CART" -> "Lore reparieren 🛒"
+                                else -> tool
+                            }
+                        )
+                    }
+                }
             }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Abbrechen") }
         }
     )
 }
@@ -248,19 +322,7 @@ private fun GameSyncOverlay() {
             .background(Color.Black.copy(alpha = 0.6f)),
         contentAlignment = Alignment.Center
     ) {
-        Card(
-            shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
-        ) {
-            Column(
-                modifier = Modifier.padding(32.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                CircularProgressIndicator()
-                Text("Synchronisierung...", style = MaterialTheme.typography.headlineSmall)
-            }
-        }
+        CircularProgressIndicator()
     }
 }
 

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -85,6 +85,28 @@ fun GameScreen(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
+
+        uiState.lastMapResult?.let { result ->
+            AlertDialog(
+                onDismissRequest = { /* schließt nach Timeout */ },
+                title = { Text("Geheim-Information") },
+                text = {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text("Du hast die Zielkarte angeschaut:")
+                        Spacer(modifier = Modifier.height(12.dp))
+                        val cardName = when (result.card.type) {
+                            CardType.GOAL -> "GOLD gefunden! 💰"
+                            else -> "Nur Stein... 🪨"
+                        }
+                        Text(cardName, style = MaterialTheme.typography.headlineMedium)
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { }) { Text("OK") }
+                }
+            )
+        }
+
         BoardGrid(
             placements = uiState.gameState.boardPlacements,
             modifier = Modifier.fillMaxSize(),

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -88,7 +88,7 @@ fun GameScreen(
 
         uiState.lastMapResult?.let { result ->
             AlertDialog(
-                onDismissRequest = { /* schließt nach Timeout */ },
+                onDismissRequest = { viewModel.dismissMapResult() },
                 title = { Text("Geheim-Information") },
                 text = {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -99,7 +99,7 @@ fun GameScreen(
                     }
                 },
                 confirmButton = {
-                    TextButton(onClick = { }) { Text("OK") }
+                    TextButton(onClick = { viewModel.dismissMapResult() }) { Text("OK") }
                 }
             )
         }

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -9,19 +9,23 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.aau.saboteur.R
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.aau.saboteur.model.PlayerTurn
-import com.aau.saboteur.ui.components.BoardGrid
-import com.aau.saboteur.ui.components.PlayerHandRow
-import com.aau.saboteur.ui.components.PlayerTurnOrderRow
-import com.aau.saboteur.ui.components.RoleCardView
+import com.aau.saboteur.model.*
+import com.aau.saboteur.ui.components.*
 import com.aau.saboteur.viewModels.GameViewModel
 import com.aau.saboteur.viewModels.LobbyViewModel
 import kotlinx.coroutines.delay
+
+private fun isBlockCard(type: CardType) =
+    type == CardType.CART_RED || type == CardType.LANTERN_RED || type == CardType.PICKAXE_RED
+
+private fun isRepairCard(type: CardType) =
+    type == CardType.CART_GREEN || type == CardType.LANTERN_GREEN || type == CardType.PICKAXE_GREEN ||
+            type == CardType.DOUBLE_LANTERN_CART || type == CardType.DOUBLE_PICKAXE_CART || type == CardType.DOUBLE_PICKAXE_LANTERN
+
+private fun needsTargetDialog(type: CardType) = isBlockCard(type) || isRepairCard(type)
 
 @Composable
 fun GameScreen(
@@ -30,7 +34,9 @@ fun GameScreen(
     viewModel: GameViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val localPlayerId by lobbyViewModel.playerId.collectAsState()
+    val localPlayerId by lobbyViewModel.playerId.collectAsState(initial = null)
+    val lobbyState by lobbyViewModel.lobbyState.collectAsState()
+    val lobbyCode = lobbyState?.lobbyCode
     val validPositions by viewModel.validPositions.collectAsState()
 
     var gameOverWinner by remember { mutableStateOf<String?>(null) }
@@ -38,28 +44,20 @@ fun GameScreen(
     LaunchedEffect(Unit) {
         viewModel.gameOverEvents.collect { winner -> gameOverWinner = winner }
     }
-    
-    val sortedPlayers = uiState.gameState.players.sortedBy(PlayerTurn::turnOrder)
+
+    LaunchedEffect(localPlayerId, lobbyCode) {
+        if (localPlayerId != null && lobbyCode != null) {
+            viewModel.initGameSession(lobbyCode!!, localPlayerId!!)
+        }
+    }
+
+    val sortedPlayers = uiState.gameState.players
     val currentHand = uiState.localPlayerId?.let { uiState.hands?.get(it) }
     val isMyTurn = uiState.localPlayerId != null &&
             uiState.gameState.currentPlayerId == uiState.localPlayerId &&
             !uiState.isSyncing
 
-    var showTurnHint by remember { mutableStateOf(false) }
-
-    LaunchedEffect(localPlayerId) {
-        viewModel.setLocalPlayerId(localPlayerId)
-    }
-
-    LaunchedEffect(isMyTurn) {
-        if (isMyTurn) {
-            showTurnHint = true
-            delay(2000)
-            showTurnHint = false
-        } else {
-            showTurnHint = false
-        }
-    }
+    var showBlockDialog by remember { mutableStateOf(false) }
 
     Box(
         modifier = Modifier
@@ -77,7 +75,6 @@ fun GameScreen(
             }
         )
 
-        // Top Header
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -106,7 +103,6 @@ fun GameScreen(
             }
         }
 
-        // Error & Hint Overlays
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
@@ -130,7 +126,6 @@ fun GameScreen(
             }
         }
 
-        // Bottom Controls
         if (currentHand != null) {
             Column(
                 modifier = Modifier
@@ -164,22 +159,85 @@ fun GameScreen(
                 PlayerHandRow(
                     hand = currentHand,
                     selectedCardId = uiState.selectedCard?.id,
-                    onCardSelected = { if (isMyTurn) viewModel.selectCard(it) },
+                    onCardSelected = { card ->
+                        if (isMyTurn) {
+                            viewModel.selectCard(card)
+                            if (needsTargetDialog(card.type)) showBlockDialog = true
+                        }
+                    },
                     onCardRotated = { card, rotated -> viewModel.onCardRotated(card, rotated) }
                 )
             }
         }
 
-        // GAME OVER OVERLAY
         gameOverWinner?.let { winner ->
             GameOverDialog(winner = winner, onBackToLobby = onBackToLobby)
         }
 
-        // SYNC OVERLAY (Reconnect Stabilität)
         if (uiState.isSyncing) {
             GameSyncOverlay()
         }
+
+        val selected = uiState.selectedCard
+        if (selected != null && needsTargetDialog(selected.type) && showBlockDialog) {
+            BlockTargetDialog(
+                playerList = uiState.gameState.players,
+                selfPlayerId = uiState.localPlayerId ?: "",
+                onPlayerSelected = { targetId ->
+                    if (isBlockCard(selected.type)) {
+                        viewModel.playBlockCardOnPlayer(targetId)
+                    } else if (isRepairCard(selected.type)) {
+                        val tool = when (selected.type) {
+                            CardType.LANTERN_GREEN -> "LANTERN"
+                            CardType.PICKAXE_GREEN -> "PICKAXE"
+                            CardType.CART_GREEN -> "CART"
+                            CardType.DOUBLE_LANTERN_CART -> "LANTERN"
+                            CardType.DOUBLE_PICKAXE_CART -> "PICKAXE"
+                            CardType.DOUBLE_PICKAXE_LANTERN -> "PICKAXE"
+                            else -> "LANTERN"
+                        }
+                        viewModel.playRepairCardOnPlayer(targetId, tool)
+                    }
+                    showBlockDialog = false
+                },
+                onDismiss = { showBlockDialog = false }
+            )
+        }
     }
+}
+
+@Composable
+fun BlockTargetDialog(
+    playerList: List<PlayerTurn>,
+    selfPlayerId: String,
+    onPlayerSelected: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Wähle einen Spieler") },
+        text = {
+            Column {
+                playerList
+                    .filter { it.playerId != selfPlayerId }
+                    .forEach { player ->
+                        Button(
+                            onClick = { onPlayerSelected(player.playerId) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp)
+                        ) {
+                            Text(player.playerName)
+                        }
+                    }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Abbrechen")
+            }
+        }
+    )
 }
 
 @Composable
@@ -200,8 +258,7 @@ private fun GameSyncOverlay() {
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 CircularProgressIndicator()
-                Text("Reconnecting...", style = MaterialTheme.typography.headlineSmall)
-                Text("Synchronizing game state with server", style = MaterialTheme.typography.bodyMedium, textAlign = TextAlign.Center)
+                Text("Synchronisierung...", style = MaterialTheme.typography.headlineSmall)
             }
         }
     }
@@ -215,7 +272,9 @@ private fun GameOverDialog(winner: String, onBackToLobby: () -> Unit) {
         else -> "Spiel beendet"
     }
     Box(
-        modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.8f)),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.8f)),
         contentAlignment = Alignment.Center
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -94,10 +94,7 @@ fun GameScreen(
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Text("Du hast die Zielkarte angeschaut:")
                         Spacer(modifier = Modifier.height(12.dp))
-                        val cardName = when (result.card.type) {
-                            CardType.GOAL -> "GOLD gefunden! 💰"
-                            else -> "Nur Stein... 🪨"
-                        }
+                        val cardName = if (result.card.isGoal) "GOLD gefunden! 💰" else "Nur Stein... 🪨"
                         Text(cardName, style = MaterialTheme.typography.headlineMedium)
                     }
                 },

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -211,6 +211,11 @@ class GameViewModel : ViewModel() {
 
         when {
             card.type == CardType.PATH || card.type == CardType.DEAD_END -> {
+                val currentPlayer = state.gameState.players.find { it.playerId == playerId }
+                if (currentPlayer != null && currentPlayer.blockedTools.isNotEmpty()) {
+                    showError("Du bist blockiert und kannst keine Tunnel legen.")
+                    return
+                }
                 GameApi.playCard(lobbyCode, playerId, card.id, position, state.selectedCardRotated)
                 _uiState.update { it.copy(selectedCard = null, selectedCardRotated = false, pendingSpecialCard = null) }
             }

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -134,6 +134,7 @@ class GameViewModel : ViewModel() {
         }
     }
 
+    // PRIVATE interne Fehlerfunktion fürs automatische Timeout
     private fun showError(message: String) {
         errorClearJob?.cancel()
         _uiState.update { it.copy(isStartingGame = false, errorMessage = message) }
@@ -141,6 +142,11 @@ class GameViewModel : ViewModel() {
             delay(2000)
             _uiState.update { it.copy(errorMessage = null) }
         }
+    }
+
+    // ÖFFENTLICHE Helper-Funktion fürs Setzen von Error-Messages von außen!
+    fun setError(msg: String) {
+        _uiState.update { it.copy(errorMessage = msg) }
     }
 
     fun initGameSession(lobbyCode: String, playerId: String) {

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -280,4 +280,7 @@ class GameViewModel : ViewModel() {
         GameApi.playRepairCard(lobbyCode, playerId, card.id, targetPlayerId, tool)
         _uiState.update { it.copy(selectedCard = null, pendingSpecialCard = null) }
     }
+    fun dismissMapResult() {
+        _uiState.update { it.copy(lastMapResult = null) }
+    }
 }

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -2,35 +2,37 @@ package com.aau.saboteur.viewModels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.aau.saboteur.model.BoardPosition
-import com.aau.saboteur.model.CardType
-import com.aau.saboteur.model.GameState
-import com.aau.saboteur.model.Player
-import com.aau.saboteur.model.TunnelCard
+import com.aau.saboteur.model.*
 import com.aau.saboteur.network.WebSocketManager
 import com.aau.saboteur.network.game.GameApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+
+private fun isBlockCard(type: CardType) =
+    type == CardType.CART_RED || type == CardType.LANTERN_RED || type == CardType.PICKAXE_RED
+
+private fun isRepairCard(type: CardType) =
+    type == CardType.CART_GREEN || type == CardType.LANTERN_GREEN || type == CardType.PICKAXE_GREEN
+            || type == CardType.DOUBLE_LANTERN_CART || type == CardType.DOUBLE_PICKAXE_CART || type == CardType.DOUBLE_PICKAXE_LANTERN
+
+private fun isMapCard(type: CardType) = type == CardType.MAPCARD
+private fun isRockfallCard(type: CardType) = type == CardType.ROCKFALL
 
 data class GameUiState(
     val isSyncing: Boolean = false,
     val isStartingGame: Boolean = false,
     val gameState: GameState = GameState(players = emptyList(), currentPlayerId = null),
+    val lobbyCode: String? = null,
     val localPlayerId: String? = null,
     val player: Player? = null,
     val hands: Map<String, List<TunnelCard>>? = null,
     val errorMessage: String? = null,
     val selectedCard: TunnelCard? = null,
     val selectedCardRotated: Boolean = false,
-    val cardRotations: Map<String, Boolean> = emptyMap()
+    val cardRotations: Map<String, Boolean> = emptyMap(),
+    val pendingSpecialCard: CardType? = null
 )
 
 class GameViewModel : ViewModel() {
@@ -53,8 +55,7 @@ class GameViewModel : ViewModel() {
         observeErrors()
         observeGameOverEvents()
         observeValidPositions()
-        
-        // Initialer Sync-Status
+
         if (_uiState.value.gameState.players.isEmpty()) {
             _uiState.update { it.copy(isSyncing = true) }
         }
@@ -64,7 +65,7 @@ class GameViewModel : ViewModel() {
         WebSocketManager.onEvent("SYNC_COMPLETE") {
             _uiState.update { it.copy(isSyncing = false) }
         }
-        
+
         viewModelScope.launch {
             WebSocketManager.connectionStatus.collect { isConnected ->
                 if (!isConnected) {
@@ -77,14 +78,17 @@ class GameViewModel : ViewModel() {
     private fun observeGameStateUpdates() {
         viewModelScope.launch {
             GameApi.gameStateUpdates.collect { newState ->
-                _uiState.update { it.copy(
-                    gameState = newState,
-                    isStartingGame = false,
-                    isSyncing = false, 
-                    errorMessage = null,
-                    selectedCard = null,
-                    selectedCardRotated = false
-                ) }
+                _uiState.update {
+                    it.copy(
+                        gameState = newState,
+                        isStartingGame = false,
+                        isSyncing = false,
+                        errorMessage = null,
+                        selectedCard = null,
+                        selectedCardRotated = false,
+                        pendingSpecialCard = null
+                    )
+                }
                 _validPositions.value = emptyList()
             }
         }
@@ -139,23 +143,37 @@ class GameViewModel : ViewModel() {
         }
     }
 
+    fun initGameSession(lobbyCode: String, playerId: String) {
+        _uiState.update { it.copy(lobbyCode = lobbyCode, localPlayerId = playerId) }
+    }
+
     fun setLocalPlayerId(playerId: String?) {
         _uiState.update { it.copy(localPlayerId = playerId) }
     }
 
     fun selectCard(card: TunnelCard) {
-        if (_uiState.value.isSyncing) return
-        val current = _uiState.value.selectedCard
+        val state = _uiState.value
+        if (state.isSyncing) return
+        val lobbyCode = state.lobbyCode ?: return
+
+        val current = state.selectedCard
         if (current?.id == card.id) {
-            _uiState.update { it.copy(selectedCard = null, selectedCardRotated = false) }
+            _uiState.update { it.copy(selectedCard = null, selectedCardRotated = false, pendingSpecialCard = null) }
             if (card.type == CardType.PATH || card.type == CardType.DEAD_END) {
                 GameApi.clearValidPositions()
             }
         } else {
-            val isRotated = _uiState.value.cardRotations[card.id] ?: card.isRotated
-            _uiState.update { it.copy(selectedCard = card, selectedCardRotated = isRotated) }
+            val isRotated = state.cardRotations[card.id] ?: card.isRotated
+            val pending = when {
+                isBlockCard(card.type) -> card.type
+                isRepairCard(card.type) -> card.type
+                isMapCard(card.type) -> card.type
+                isRockfallCard(card.type) -> card.type
+                else -> null
+            }
+            _uiState.update { it.copy(selectedCard = card, selectedCardRotated = isRotated, pendingSpecialCard = pending) }
             if (card.type == CardType.PATH || card.type == CardType.DEAD_END) {
-                GameApi.requestValidPositions(card.id, isRotated)
+                GameApi.requestValidPositions(lobbyCode, card.id, isRotated)
             } else {
                 GameApi.clearValidPositions()
             }
@@ -163,44 +181,83 @@ class GameViewModel : ViewModel() {
     }
 
     fun onCardRotated(card: TunnelCard, isRotated: Boolean) {
-        if (_uiState.value.isSyncing) return
-        val newRotations = _uiState.value.cardRotations + (card.id to isRotated)
-        val newSelectedCardRotated = if (_uiState.value.selectedCard?.id == card.id) isRotated
-                                     else _uiState.value.selectedCardRotated
-        _uiState.update { it.copy(
-            cardRotations = newRotations,
-            selectedCardRotated = newSelectedCardRotated
-        ) }
-        if (_uiState.value.selectedCard?.id == card.id &&
-            (card.type == CardType.PATH || card.type == CardType.DEAD_END)) {
-            GameApi.requestValidPositions(card.id, isRotated)
+        val state = _uiState.value
+        if (state.isSyncing) return
+        val lobbyCode = state.lobbyCode ?: return
+
+        val newRotations = state.cardRotations + (card.id to isRotated)
+        val newSelectedCardRotated = if (state.selectedCard?.id == card.id) isRotated
+        else state.selectedCardRotated
+
+        _uiState.update {
+            it.copy(
+                cardRotations = newRotations,
+                selectedCardRotated = newSelectedCardRotated
+            )
+        }
+
+        if (state.selectedCard?.id == card.id && (card.type == CardType.PATH || card.type == CardType.DEAD_END)) {
+            GameApi.requestValidPositions(lobbyCode, card.id, isRotated)
         }
     }
 
     fun onBoardCellClicked(position: BoardPosition) {
         val state = _uiState.value
+        val lobbyCode = state.lobbyCode ?: return
         if (state.isSyncing) return
         val card = state.selectedCard ?: return
         val playerId = state.localPlayerId ?: return
         if (state.gameState.currentPlayerId != playerId) return
 
-        if (card.type != CardType.PATH && card.type != CardType.DEAD_END) {
-            showError("Diese Karte kann hier nicht platziert werden.")
-            return
+        when {
+            card.type == CardType.PATH || card.type == CardType.DEAD_END -> {
+                GameApi.playCard(lobbyCode, playerId, card.id, position, state.selectedCardRotated)
+                _uiState.update { it.copy(selectedCard = null, selectedCardRotated = false, pendingSpecialCard = null) }
+            }
+            isMapCard(card.type) -> {
+                GameApi.playMapCard(lobbyCode, playerId, card.id, position)
+                _uiState.update { it.copy(selectedCard = null, pendingSpecialCard = null) }
+            }
+            isRockfallCard(card.type) -> {
+                GameApi.playRockfallCard(lobbyCode, playerId, card.id, position)
+                _uiState.update { it.copy(selectedCard = null, pendingSpecialCard = null) }
+            }
+            else -> showError("Diese Karte kann hier nicht auf das Feld gespielt werden.")
         }
-
-        GameApi.playCard(playerId, card.id, position, state.selectedCardRotated)
     }
 
     fun discardSelectedCard() {
         val state = _uiState.value
+        val lobbyCode = state.lobbyCode ?: return
         if (state.isSyncing) return
         val card = state.selectedCard ?: return
         val playerId = state.localPlayerId ?: return
         if (state.gameState.currentPlayerId != playerId) return
 
-        GameApi.discardCard(playerId, card.id)
-        _uiState.update { it.copy(selectedCard = null, selectedCardRotated = false) }
+        GameApi.discardCard(lobbyCode, playerId, card.id)
+        _uiState.update { it.copy(selectedCard = null, selectedCardRotated = false, pendingSpecialCard = null) }
         GameApi.clearValidPositions()
+    }
+
+    fun playBlockCardOnPlayer(targetPlayerId: String) {
+        val state = _uiState.value
+        val lobbyCode = state.lobbyCode ?: return
+        val card = state.selectedCard ?: return
+        val playerId = state.localPlayerId ?: return
+        if (state.isSyncing || state.gameState.currentPlayerId != playerId || !isBlockCard(card.type)) return
+
+        GameApi.playBlockCard(lobbyCode, playerId, card.id, targetPlayerId)
+        _uiState.update { it.copy(selectedCard = null, pendingSpecialCard = null) }
+    }
+
+    fun playRepairCardOnPlayer(targetPlayerId: String, tool: String) {
+        val state = _uiState.value
+        val lobbyCode = state.lobbyCode ?: return
+        val card = state.selectedCard ?: return
+        val playerId = state.localPlayerId ?: return
+        if (state.isSyncing || state.gameState.currentPlayerId != playerId || !isRepairCard(card.type)) return
+
+        GameApi.playRepairCard(lobbyCode, playerId, card.id, targetPlayerId, tool)
+        _uiState.update { it.copy(selectedCard = null, pendingSpecialCard = null) }
     }
 }

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.aau.saboteur.model.*
 import com.aau.saboteur.network.WebSocketManager
 import com.aau.saboteur.network.game.GameApi
+import com.aau.saboteur.network.game.MapResult
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
@@ -32,7 +33,8 @@ data class GameUiState(
     val selectedCard: TunnelCard? = null,
     val selectedCardRotated: Boolean = false,
     val cardRotations: Map<String, Boolean> = emptyMap(),
-    val pendingSpecialCard: CardType? = null
+    val pendingSpecialCard: CardType? = null,
+    val lastMapResult: MapResult? = null
 )
 
 class GameViewModel : ViewModel() {
@@ -55,7 +57,7 @@ class GameViewModel : ViewModel() {
         observeErrors()
         observeGameOverEvents()
         observeValidPositions()
-
+        observeMapResults()
         if (_uiState.value.gameState.players.isEmpty()) {
             _uiState.update { it.copy(isSyncing = true) }
         }
@@ -65,7 +67,6 @@ class GameViewModel : ViewModel() {
         WebSocketManager.onEvent("SYNC_COMPLETE") {
             _uiState.update { it.copy(isSyncing = false) }
         }
-
         viewModelScope.launch {
             WebSocketManager.connectionStatus.collect { isConnected ->
                 if (!isConnected) {
@@ -134,7 +135,16 @@ class GameViewModel : ViewModel() {
         }
     }
 
-    // PRIVATE interne Fehlerfunktion fürs automatische Timeout
+    private fun observeMapResults() {
+        viewModelScope.launch {
+            GameApi.mapResultEvents.collect { result ->
+                _uiState.update { it.copy(lastMapResult = result) }
+                delay(5000)
+                _uiState.update { it.copy(lastMapResult = null) }
+            }
+        }
+    }
+
     private fun showError(message: String) {
         errorClearJob?.cancel()
         _uiState.update { it.copy(isStartingGame = false, errorMessage = message) }
@@ -144,7 +154,6 @@ class GameViewModel : ViewModel() {
         }
     }
 
-    // ÖFFENTLICHE Helper-Funktion fürs Setzen von Error-Messages von außen!
     fun setError(msg: String) {
         _uiState.update { it.copy(errorMessage = msg) }
     }

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/LobbyViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/LobbyViewModel.kt
@@ -203,10 +203,16 @@ class LobbyViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun startGame() {
-        val players = _lobbyState.value?.players.orEmpty()
+        val state = _lobbyState.value ?: return
+        val players = state.players
+        val lobbyCode = state.lobbyCode
+
         if (players.isEmpty()) return
+
         _errorMessage.value = null
-        GameApi.startGame(players)
+
+
+        GameApi.startGame(lobbyCode, players)
     }
 
     fun refreshLobbies() {

--- a/shared/src/commonMain/kotlin/com/aau/saboteur/model/Player.kt
+++ b/shared/src/commonMain/kotlin/com/aau/saboteur/model/Player.kt
@@ -7,5 +7,6 @@ data class Player(
     val id: String = "",
     val name: String = "",
     val hand: List<TunnelCard> = emptyList(),
-    val role: Role? = null
+    val role: Role? = null,
+    val blockedTools: Set<ToolType> = emptySet()
 )


### PR DESCRIPTION


1. GameApi sendet jetzt alle Spezialkarten-Befehle (playBlockCard, playRepairCard, playMapCard, playRockfallCard) über WebSockets an den Server.

2. GameViewModel enthält die komplette Spezialkarten-Logik – Spezialkarten werden jetzt korrekt verarbeitet und können samt Zielauswahl gespielt werden (kein pauschaler Fehler mehr).

3. GameScreen bietet die nutzerfreundliche UI für die Zielauswahl:

- Für Block- und Repair-Karten erscheint ein Dialog mit Spielerliste

- Map- und Rockfall-Karten können nun durch Klick auf das Boardfeld gezielt eingesetzt werden

Das Feature ist damit vollständig Ende-zu-Ende für alle Kartentypen integriert.

Die Build- und Unit-Tests laufen auf Client- und Server-Seite fehlerfrei.