### PR TITLE
Fix server datasource URL to work on Windows and Mac

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.address=0.0.0.0
 server.port=8080
 
 # H2 Datenbank Setup - Persistent for Docker volume
-spring.datasource.url=jdbc:h2:file:/data/saboteur_db;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE
+spring.datasource.url=jdbc:h2:file:${user.home}/.saboteur/saboteur_db;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -5,7 +5,7 @@ server.address=0.0.0.0
 server.port=8080
 
 # H2 Datenbank Setup - Persistent for Docker volume
-spring.datasource.url=jdbc:h2:file:${user.home}/.saboteur/saboteur_db;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:h2:file:${user.home}/.saboteur/saboteur_db};DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password


### PR DESCRIPTION
   Use ${user.home} instead of hardcoded /data path so H2 database
   resolves correctly on both platforms without Docker volume.