### PR TITLE
fix(deploy): move server .env mounting into volumes block to fix doco-cd crash

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,11 +7,10 @@ services:
     ports:
       - "53207:8080"
 
-    env_file:
-      - /home/grp-3/.env
 
     volumes:
       - saboteur_data:/data
+      - /home/grp-3/.env:/app/.env
 
 volumes:
   saboteur_data:


### PR DESCRIPTION
## 🚀 Problembehebung: doco-cd Deployment-Crash gefixt

### 📝 Beschreibung
Dieser PR behebt den Fehler beim automatischen Deployment über das universitäre `doco-cd`-System. 

Bisher ist das Deployment mit folgender Fehlermeldung abgebrochen:
> `failed to load compose project: env file /home/grp-3/.env not found: stat /home/grp-3/.env: no such file or directory`

**Ursache:** Der Deployment-Dienst `doco-cd` läuft isoliert und hat vor dem Container-Start keinen direkten Zugriff auf absolute Pfade des Host-Systems (wie `/home/grp-3/`), wenn diese im `env_file`-Block deklariert sind. Dadurch schlug die Konfigurations-Validierung fehl.

### 🛠️ Durchgeführte Änderungen
* **`env_file` Block entfernt:** Die fehlerhafte absolute Pfadangabe wurde gelöscht, damit der Validierungs-Bot nicht mehr abstürzt.
* **Volume-basiertes Mounting hinzugefügt:** Die servergünstige `.env`-Datei wird nun über den `volumes`-Block direkt an `/app/.env` im Container gemountet. 
* **Vorteil:** `doco-cd` ignoriert diese Host-Pfade bei der ersten Validierung. Sobald Docker den Container auf der VM startet, wird die Datei sicher injiziert. Spring Boot liest sie im Arbeitsverzeichnis `/app` automatisch aus. Unsere Geheimnisse/Passwörter bleiben sicher auf dem Server und landen nicht im Git.

### 🧪 Verifikation & Test
1. Änderungen lokal auf Validität geprüft (`docker compose config`).