### PR TITLE
fix: add default value for is_guest column to allow ddl-auto=update m…

### DIFF
--- a/server/src/main/kotlin/com/aau/server/model/UserEntity.kt
+++ b/server/src/main/kotlin/com/aau/server/model/UserEntity.kt
@@ -23,7 +23,7 @@ class UserEntity(
     @Column(unique = true, nullable = false)
     var playerId: String = UUID.randomUUID().toString(),
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "boolean default false")
     var isGuest: Boolean = false
 ) {
     constructor() : this(null, "", "", UUID.randomUUID().toString(), false)


### PR DESCRIPTION
##Problem:
Nach dem Merge von feature/private-and-social startet der Server nicht mehr, wenn eine bestehende H2-Datenbank vorhanden ist:

Error executing DDL "alter table if exists users add column is_guest boolean not null"
  via JDBC [NULL nicht zulässig für Feld "IS_GUEST"]

##Ursache: 
Das neue Feld isGuest in UserEntity ist als nullable = false deklariert, ohne einen Datenbank-Default-Wert zu definieren. Bei ddl-auto=update generiert Hibernate ein
  ALTER TABLE users ADD COLUMN is_guest boolean not null. H2 lehnt dieses Statement ab, weil bestehende Zeilen für die neue Spalte keinen Wert hätten.

##Fix:
  columnDefinition = "boolean default false" in der @Column-Annotation ergänzt. Damit befüllt H2 beim ALTER TABLE alle bestehenden Zeilen automatisch mit false — was semantisch
  korrekt ist, da bestehende User registrierte Accounts sind.