### PR TITLE
feat: #104 #107 - Blocked tools display and round result screen

### DIFF
--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     testImplementation(libs.androidx.junit)
     testImplementation(libs.mockwebserver)
     testImplementation(libs.robolectric)
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 

--- a/app/app/src/androidTest/java/com/aau/saboteur/ui/screens/ResultScreensTest.kt
+++ b/app/app/src/androidTest/java/com/aau/saboteur/ui/screens/ResultScreensTest.kt
@@ -71,7 +71,7 @@ class ResultScreensTest {
     }
 
     @Test
-    fun roundResultScreenDisplaysGoldiggerWinner() {
+    fun roundResultScreenDisplaysGolddiggerWinner() {
         composeTestRule.setContent {
             SE2GameTheme {
                 RoundResultScreen(
@@ -163,7 +163,7 @@ class ResultScreensTest {
     }
 
     @Test
-    fun finalResultScreenDisplaysGoldiggerWinner() {
+    fun finalResultScreenDisplaysGolddiggerWinner() {
         composeTestRule.setContent {
             SE2GameTheme {
                 FinalResultScreen(

--- a/app/app/src/androidTest/java/com/aau/saboteur/ui/screens/ResultScreensTest.kt
+++ b/app/app/src/androidTest/java/com/aau/saboteur/ui/screens/ResultScreensTest.kt
@@ -1,0 +1,322 @@
+package com.aau.saboteur.ui.screens
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.aau.saboteur.model.PlayerTurn
+import com.aau.saboteur.model.Role
+import com.aau.saboteur.model.RoundResult
+import com.aau.saboteur.ui.theme.SE2GameTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ResultScreensTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val mockPlayers = listOf(
+        PlayerTurn(playerId = "1", playerName = "Stefan"),
+        PlayerTurn(playerId = "2", playerName = "Lukas"),
+        PlayerTurn(playerId = "3", playerName = "Chris")
+    )
+
+    private val mockRoundResult = RoundResult(
+        roundNumber = 1,
+        winnerRole = Role.GOLDDIGGER,
+        winningPlayerIds = listOf("1", "3"),
+        revealedRoles = mapOf(
+            "1" to Role.GOLDDIGGER,
+            "2" to Role.SABOTEUR,
+            "3" to Role.GOLDDIGGER
+        ),
+        playerGoldTotals = mapOf(
+            "1" to 5,
+            "2" to 0,
+            "3" to 3
+        )
+    )
+
+    private val mockFinalResult = RoundResult(
+        roundNumber = 3,
+        winnerRole = Role.GOLDDIGGER,
+        winningPlayerIds = listOf("1", "3"),
+        revealedRoles = mapOf(
+            "1" to Role.GOLDDIGGER,
+            "2" to Role.SABOTEUR,
+            "3" to Role.GOLDDIGGER
+        ),
+        playerGoldTotals = mapOf(
+            "1" to 12,
+            "2" to 5,
+            "3" to 10
+        )
+    )
+
+    // ===== ROUND RESULT SCREEN TESTS =====
+
+    @Test
+    fun roundResultScreenDisplaysRoundNumber() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                RoundResultScreen(
+                    roundResult = mockRoundResult,
+                    players = mockPlayers,
+                    onNextRound = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Runde 1 beendet").assertExists()
+    }
+
+    @Test
+    fun roundResultScreenDisplaysGoldiggerWinner() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                RoundResultScreen(
+                    roundResult = mockRoundResult,
+                    players = mockPlayers,
+                    onNextRound = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Goldsucher gewinnen").assertExists()
+    }
+
+    @Test
+    fun roundResultScreenDisplaysAllPlayerNames() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                RoundResultScreen(
+                    roundResult = mockRoundResult,
+                    players = mockPlayers,
+                    onNextRound = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Stefan").assertExists()
+        composeTestRule.onNodeWithText("Lukas").assertExists()
+        composeTestRule.onNodeWithText("Chris").assertExists()
+    }
+
+    @Test
+    fun roundResultScreenNextRoundButtonTriggersCallback() {
+        var callbackTriggered = false
+        composeTestRule.setContent {
+            SE2GameTheme {
+                RoundResultScreen(
+                    roundResult = mockRoundResult,
+                    players = mockPlayers,
+                    onNextRound = { callbackTriggered = true }
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Weiter zur nächsten Runde").performClick()
+        assert(callbackTriggered)
+    }
+
+    @Test
+    fun roundResultScreenDisplaysSaboteurWinner() {
+        val saboteurRoundResult = mockRoundResult.copy(winnerRole = Role.SABOTEUR)
+        composeTestRule.setContent {
+            SE2GameTheme {
+                RoundResultScreen(
+                    roundResult = saboteurRoundResult,
+                    players = mockPlayers,
+                    onNextRound = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Saboteure gewinnen").assertExists()
+    }
+
+    @Test
+    fun roundResultScreenDisplaysRoleHeader() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                RoundResultScreen(
+                    roundResult = mockRoundResult,
+                    players = mockPlayers,
+                    onNextRound = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Rollen dieser Runde").assertExists()
+    }
+
+    // ===== FINAL RESULT SCREEN TESTS =====
+
+    @Test
+    fun finalResultScreenDisplaysGameEndedHeader() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = mockFinalResult,
+                    players = mockPlayers,
+                    onNewGame = {},
+                    onLeaveGame = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Spiel beendet").assertExists()
+    }
+
+    @Test
+    fun finalResultScreenDisplaysGoldiggerWinner() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = mockFinalResult,
+                    players = mockPlayers,
+                    onNewGame = {},
+                    onLeaveGame = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Goldsucher gewinnen").assertExists()
+    }
+
+    @Test
+    fun finalResultScreenDisplaysWinnerName() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = mockFinalResult,
+                    players = mockPlayers,
+                    onNewGame = {},
+                    onLeaveGame = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Stefan").assertExists()
+    }
+
+    @Test
+    fun finalResultScreenDisplaysGoldCount() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = mockFinalResult,
+                    players = mockPlayers,
+                    onNewGame = {},
+                    onLeaveGame = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("12").assertExists()
+    }
+
+    @Test
+    fun finalResultScreenDisplaysAllPlayerNames() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = mockFinalResult,
+                    players = mockPlayers,
+                    onNewGame = {},
+                    onLeaveGame = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Stefan").assertExists()
+        composeTestRule.onNodeWithText("Lukas").assertExists()
+        composeTestRule.onNodeWithText("Chris").assertExists()
+    }
+
+    @Test
+    fun finalResultScreenDisplaysFinalScoresHeader() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = mockFinalResult,
+                    players = mockPlayers,
+                    onNewGame = {},
+                    onLeaveGame = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Endgültiger Goldstand").assertExists()
+    }
+
+    @Test
+    fun finalResultScreenNewGameButtonTriggersCallback() {
+        var newGameClicked = false
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = mockFinalResult,
+                    players = mockPlayers,
+                    onNewGame = { newGameClicked = true },
+                    onLeaveGame = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Neues Spiel").performClick()
+        assert(newGameClicked)
+    }
+
+    @Test
+    fun finalResultScreenLeaveGameButtonTriggersCallback() {
+        var leaveGameClicked = false
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = mockFinalResult,
+                    players = mockPlayers,
+                    onNewGame = {},
+                    onLeaveGame = { leaveGameClicked = true }
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Beenden").performClick()
+        assert(leaveGameClicked)
+    }
+
+    @Test
+    fun finalResultScreenDisplaysSaboteurWinner() {
+        val saboteurFinalResult = mockFinalResult.copy(winnerRole = Role.SABOTEUR)
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = saboteurFinalResult,
+                    players = mockPlayers,
+                    onNewGame = {},
+                    onLeaveGame = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Saboteure gewinnen").assertExists()
+    }
+
+    @Test
+    fun finalResultScreenDisplaysLastRoleHeading() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = mockFinalResult,
+                    players = mockPlayers,
+                    onNewGame = {},
+                    onLeaveGame = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Rollen der letzten Runde").assertExists()
+    }
+
+    @Test
+    fun finalResultScreenDisplaysTwoButtons() {
+        composeTestRule.setContent {
+            SE2GameTheme {
+                FinalResultScreen(
+                    roundResult = mockFinalResult,
+                    players = mockPlayers,
+                    onNewGame = {},
+                    onLeaveGame = {}
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("Neues Spiel").assertExists()
+        composeTestRule.onNodeWithText("Beenden").assertExists()
+    }
+}

--- a/app/app/src/main/java/com/aau/saboteur/navigation/AppNavHost.kt
+++ b/app/app/src/main/java/com/aau/saboteur/navigation/AppNavHost.kt
@@ -106,11 +106,15 @@ fun AppNavHost(
                     lobbyViewModel = lobbyViewModel,
                     onBackToLobby = {
                         val username = lobbyViewModel.username.value
-                        // WICHTIG: Lobby- und Game-State lokal komplett zurücksetzen
                         lobbyViewModel.resetLobby()
-                        
                         navController.navigate("lobby/$username") {
-                            // Gesamten Backstack löschen um "Zurück-Springen" ins Spiel zu verhindern
+                            popUpTo(0) { inclusive = true }
+                        }
+                    },
+                    onBackToActiveLobby = {
+                        val username = lobbyViewModel.username.value
+                        GameApi.reset()
+                        navController.navigate("activeLobby/$username") {
                             popUpTo(0) { inclusive = true }
                         }
                     }

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/PlayerCard.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/PlayerCard.kt
@@ -2,12 +2,14 @@ package com.aau.saboteur.ui.components
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -22,6 +24,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.aau.saboteur.ui.theme.GlowGold
 import com.aau.saboteur.ui.theme.MineCoal
 import com.aau.saboteur.ui.theme.MineSlate
@@ -46,11 +49,6 @@ fun PlayerCard(
         Brush.linearGradient(
             colors = listOf(MineCoal, MineSlate)
         )
-    }
-    val toolEmojis = buildString {
-        if (player.blockedTools.any { it.name == "PICKAXE" }) append("⛏️")
-        if (player.blockedTools.any { it.name == "LANTERN" }) append("🏮")
-        if (player.blockedTools.any { it.name == "CART" }) append("🛒")
     }
 
     Card(
@@ -94,13 +92,27 @@ fun PlayerCard(
                         fontWeight = FontWeight.SemiBold,
                         color = if (isCurrentPlayer) MineCoal else Quartz
                     )
-                    if (toolEmojis.isNotEmpty()) {
+                    if (player.blockedTools.isNotEmpty()) {
                         Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = toolEmojis,
-                            color = if (isCurrentPlayer) MineCoal else Quartz,
-                            style = MaterialTheme.typography.bodyLarge
-                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            player.blockedTools.forEach { tool ->
+                                val emoji = when (tool.name) {
+                                    "PICKAXE" -> "⛏️"
+                                    "LANTERN" -> "🏮"
+                                    "CART" -> "🛒"
+                                    else -> ""
+                                }
+                                Box(
+                                    modifier = Modifier
+                                        .size(24.dp)
+                                        .border(2.dp, Color.Red, MaterialTheme.shapes.small),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(emoji, fontSize = 14.sp)
+                                }
+                                Spacer(modifier = Modifier.width(4.dp))
+                            }
+                        }
                     }
                 }
             }

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/FinalResultScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/FinalResultScreen.kt
@@ -119,7 +119,11 @@ fun FinalResultScreen(
                     ) {
                         items(players) { player ->
                             val revealedRole = roundResult.revealedRoles[player.playerId]
-                            val roleIcon = if (revealedRole == Role.GOLDDIGGER) "⛏️" else "🔴"
+                            val roleIcon = when (revealedRole) {
+                                Role.GOLDDIGGER -> "⛏️"
+                                Role.SABOTEUR -> "🔴"
+                                null -> "❓"
+                            }
                             val roleText = if (revealedRole == Role.GOLDDIGGER) "Goldsucher" else "Saboteur"
                             val roleColor = if (revealedRole == Role.GOLDDIGGER)
                                 OreGold else Color(0xFFD32F2F)

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/FinalResultScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/FinalResultScreen.kt
@@ -1,0 +1,315 @@
+package com.aau.saboteur.ui.screens
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.aau.saboteur.model.PlayerTurn
+import com.aau.saboteur.model.Role
+import com.aau.saboteur.model.RoundResult
+import com.aau.saboteur.ui.theme.OreGold
+
+@Composable
+fun FinalResultScreen(
+    roundResult: RoundResult,
+    players: List<PlayerTurn>,
+    onNewGame: () -> Unit,
+    onLeaveGame: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .wrapContentHeight(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                ),
+                border = BorderStroke(2.dp, OreGold),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        text = "🏆 Spiel beendet",
+                        style = MaterialTheme.typography.headlineMedium.copy(
+                            fontSize = 28.sp,
+                            fontWeight = FontWeight.ExtraBold,
+                            fontFamily = FontFamily.SansSerif
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center
+                    )
+
+                    val winnerColor = if (roundResult.winnerRole == Role.GOLDDIGGER)
+                        OreGold else Color(0xFFD32F2F)
+                    val winnerIcon = if (roundResult.winnerRole == Role.GOLDDIGGER) "⛏️" else "🔴"
+                    val winnerText = if (roundResult.winnerRole == Role.GOLDDIGGER)
+                        "Goldsucher gewinnen" else "Saboteure gewinnen"
+
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                        color = winnerColor.copy(alpha = 0.2f),
+                        border = BorderStroke(1.dp, winnerColor)
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(12.dp),
+                            horizontalArrangement = Arrangement.Center,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(winnerIcon, fontSize = 20.sp)
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = winnerText,
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontWeight = FontWeight.Bold,
+                                    fontFamily = FontFamily.SansSerif
+                                ),
+                                color = winnerColor
+                            )
+                        }
+                    }
+
+                    Text(
+                        text = "Rollen der letzten Runde",
+                        style = MaterialTheme.typography.labelMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = FontFamily.SansSerif
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Start
+                    )
+
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 120.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        items(players) { player ->
+                            val revealedRole = roundResult.revealedRoles[player.playerId]
+                            val roleIcon = if (revealedRole == Role.GOLDDIGGER) "⛏️" else "🔴"
+                            val roleText = if (revealedRole == Role.GOLDDIGGER) "Goldsucher" else "Saboteur"
+                            val roleColor = if (revealedRole == Role.GOLDDIGGER)
+                                OreGold else Color(0xFFD32F2F)
+
+                            Surface(
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = RoundedCornerShape(8.dp),
+                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(10.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+                                    ) {
+                                        Text(roleIcon, fontSize = 16.sp)
+                                        Text(
+                                            text = player.playerName,
+                                            style = MaterialTheme.typography.bodySmall.copy(
+                                                fontFamily = FontFamily.SansSerif
+                                            ),
+                                            color = MaterialTheme.colorScheme.onSurface
+                                        )
+                                    }
+                                    Text(
+                                        text = roleText,
+                                        style = MaterialTheme.typography.bodySmall.copy(
+                                            fontWeight = FontWeight.Bold,
+                                            fontFamily = FontFamily.SansSerif
+                                        ),
+                                        color = roleColor
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    HorizontalDivider(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 8.dp),
+                        color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+                    )
+
+                    Text(
+                        text = "Endgültiger Goldstand",
+                        style = MaterialTheme.typography.labelMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = FontFamily.SansSerif
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.fillMaxWidth(),
+                        textAlign = TextAlign.Start
+                    )
+
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 100.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        items(
+                            roundResult.playerGoldTotals.entries.sortedByDescending { it.value }
+                        ) { (playerId, gold) ->
+                            val playerName = players.find { it.playerId == playerId }?.playerName ?: "Unknown"
+
+                            Surface(
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = RoundedCornerShape(8.dp),
+                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(10.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(
+                                        text = playerName,
+                                        style = MaterialTheme.typography.bodySmall.copy(
+                                            fontFamily = FontFamily.SansSerif
+                                        ),
+                                        color = MaterialTheme.colorScheme.onSurface
+                                    )
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                                    ) {
+                                        Text(
+                                            text = gold.toString(),
+                                            style = MaterialTheme.typography.bodySmall.copy(
+                                                fontWeight = FontWeight.Bold,
+                                                fontFamily = FontFamily.SansSerif
+                                            ),
+                                            color = OreGold
+                                        )
+                                        Text("🪙", fontSize = 14.sp)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        color = OreGold.copy(alpha = 0.15f),
+                        border = BorderStroke(1.dp, OreGold.copy(alpha = 0.5f))
+                    ) {
+                        val winnerPlayer = players.find { player ->
+                            roundResult.playerGoldTotals[player.playerId] ==
+                                    roundResult.playerGoldTotals.values.maxOrNull()
+                        }
+                        val winnerGold = roundResult.playerGoldTotals.values.maxOrNull() ?: 0
+
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(12.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Text(
+                                text = "🏆 ${winnerPlayer?.playerName ?: "Unknown"} gewinnt mit $winnerGold Goldstücken",
+                                style = MaterialTheme.typography.bodyMedium.copy(
+                                    fontWeight = FontWeight.ExtraBold,
+                                    fontFamily = FontFamily.SansSerif
+                                ),
+                                color = OreGold,
+                                textAlign = TextAlign.Center
+                            )
+                        }
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Button(
+                    onClick = onNewGame,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(48.dp),
+                    shape = RoundedCornerShape(8.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                ) {
+                    Text(
+                        "Neues Spiel",
+                        style = MaterialTheme.typography.titleSmall.copy(
+                            fontWeight = FontWeight.ExtraBold,
+                            fontFamily = FontFamily.SansSerif
+                        )
+                    )
+                }
+
+                Button(
+                    onClick = onLeaveGame,
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(48.dp),
+                    shape = RoundedCornerShape(8.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.secondary,
+                        contentColor = MaterialTheme.colorScheme.onSecondary
+                    )
+                ) {
+                    Text(
+                        "Beenden",
+                        style = MaterialTheme.typography.titleSmall.copy(
+                            fontWeight = FontWeight.ExtraBold,
+                            fontFamily = FontFamily.SansSerif
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/FinalResultScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/FinalResultScreen.kt
@@ -25,8 +25,7 @@ import com.aau.saboteur.ui.theme.OreGold
 fun FinalResultScreen(
     roundResult: RoundResult,
     players: List<PlayerTurn>,
-    onNewGame: () -> Unit,
-    onLeaveGame: () -> Unit
+    onBackToLobby: () -> Unit
 ) {
     Box(
         modifier = Modifier
@@ -275,51 +274,24 @@ fun FinalResultScreen(
                 }
             }
 
-            Row(
+            Button(
+                onClick = onBackToLobby,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .wrapContentHeight(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    .height(48.dp),
+                shape = RoundedCornerShape(8.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
             ) {
-                Button(
-                    onClick = onNewGame,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(48.dp),
-                    shape = RoundedCornerShape(8.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary
+                Text(
+                    "Zurück zur Lobby",
+                    style = MaterialTheme.typography.titleSmall.copy(
+                        fontWeight = FontWeight.ExtraBold,
+                        fontFamily = FontFamily.SansSerif
                     )
-                ) {
-                    Text(
-                        "Neues Spiel",
-                        style = MaterialTheme.typography.titleSmall.copy(
-                            fontWeight = FontWeight.ExtraBold,
-                            fontFamily = FontFamily.SansSerif
-                        )
-                    )
-                }
-
-                Button(
-                    onClick = onLeaveGame,
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(48.dp),
-                    shape = RoundedCornerShape(8.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.secondary,
-                        contentColor = MaterialTheme.colorScheme.onSecondary
-                    )
-                ) {
-                    Text(
-                        "Beenden",
-                        style = MaterialTheme.typography.titleSmall.copy(
-                            fontWeight = FontWeight.ExtraBold,
-                            fontFamily = FontFamily.SansSerif
-                        )
-                    )
-                }
+                )
             }
         }
     }

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/FinalResultScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/FinalResultScreen.kt
@@ -124,9 +124,16 @@ fun FinalResultScreen(
                                 Role.SABOTEUR -> "🔴"
                                 null -> "❓"
                             }
-                            val roleText = if (revealedRole == Role.GOLDDIGGER) "Goldsucher" else "Saboteur"
-                            val roleColor = if (revealedRole == Role.GOLDDIGGER)
-                                OreGold else Color(0xFFD32F2F)
+                            val roleText = when (revealedRole) {
+                                Role.GOLDDIGGER -> "Goldsucher"
+                                Role.SABOTEUR -> "Saboteur"
+                                null -> "Unbekannt"
+                            }
+                            val roleColor = when (revealedRole) {
+                                Role.GOLDDIGGER -> OreGold
+                                Role.SABOTEUR -> Color(0xFFD32F2F)
+                                null -> Color.Gray
+                            }
 
                             Surface(
                                 modifier = Modifier.fillMaxWidth(),

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -2,7 +2,6 @@ package com.aau.saboteur.ui.screens
 
 import android.content.Context
 import android.hardware.camera2.CameraManager
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
@@ -19,14 +18,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.aau.saboteur.R
 import com.aau.saboteur.model.*
 import com.aau.saboteur.ui.components.*
 import com.aau.saboteur.viewModels.GameViewModel
 import com.aau.saboteur.viewModels.LobbyViewModel
-import androidx.compose.foundation.layout.size
-import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.BorderStroke
 
 private val DeckBadgeBackground = Color(0xFF2A2A2A)
 private val DeckBadgeIconBackground = Color(0xFF1A1A1A)
@@ -99,13 +98,10 @@ fun GameScreen(
     val lobbyState by lobbyViewModel.lobbyState.collectAsState()
     val lobbyCode = lobbyState?.lobbyCode
     val validPositions by viewModel.validPositions.collectAsState()
-    var gameOverWinner by remember { mutableStateOf<String?>(null) }
     var showRoundResult by remember { mutableStateOf(false) }
     var showFinalResult by remember { mutableStateOf(false) }
 
-    LaunchedEffect(Unit) {
-        viewModel.gameOverEvents.collect { winner -> gameOverWinner = winner }
-    }
+
 
     LaunchedEffect(Unit) {
         viewModel.roundResultScreenRequested.collect {
@@ -302,9 +298,7 @@ fun GameScreen(
                 )
             }
         }
-        gameOverWinner?.let { winner ->
-            GameOverDialog(winner = winner, onBackToLobby = onBackToLobby)
-        }
+
         if (uiState.isSyncing) {
             GameSyncOverlay()
         }
@@ -511,26 +505,6 @@ private fun GameSyncOverlay() {
     }
 }
 
-@Composable
-private fun GameOverDialog(winner: String, onBackToLobby: () -> Unit) {
-    val resultText = when (winner) {
-        "DWARVES" -> stringResource(R.string.dwarves_win)
-        "SABOTEURS" -> stringResource(R.string.saboteurs_win)
-        else -> stringResource(R.string.game_over)
-    }
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.8f)),
-        contentAlignment = Alignment.Center
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(text = resultText, style = MaterialTheme.typography.displayMedium, color = Color.White)
-            Spacer(modifier = Modifier.height(48.dp))
-            Button(onClick = onBackToLobby) { Text(stringResource(R.string.back_to_lobby_button)) }
-        }
-    }
-}
 
 @Composable
 private fun localizeServerError(code: String): String = when (code) {

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -25,6 +25,11 @@ import com.aau.saboteur.model.*
 import com.aau.saboteur.ui.components.*
 import com.aau.saboteur.viewModels.GameViewModel
 import com.aau.saboteur.viewModels.LobbyViewModel
+import com.aau.saboteur.ui.screens.RoundResultScreen
+import com.aau.saboteur.ui.screens.FinalResultScreen
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.unit.sp
 
 private val DeckBadgeBackground = Color(0xFF2A2A2A)
 private val DeckBadgeIconBackground = Color(0xFF1A1A1A)
@@ -63,10 +68,26 @@ private fun getRepairToolsFromCard(type: CardType): List<String> = when(type) {
 
 @Composable
 private fun ToolIcons(blockedTools: Set<ToolType>) {
-    Row(verticalAlignment = Alignment.CenterVertically) {
-        if (blockedTools.any { it.name == "PICKAXE" }) Text("⛏️")
-        if (blockedTools.any { it.name == "LANTERN" }) Text("🏮")
-        if (blockedTools.any { it.name == "CART" }) Text("🛒")
+    if (blockedTools.isNotEmpty()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            blockedTools.forEach { tool ->
+                val emoji = when (tool.name) {
+                    "PICKAXE" -> "⛏️"
+                    "LANTERN" -> "🏮"
+                    "CART" -> "🛒"
+                    else -> ""
+                }
+                Box(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .border(2.dp, Color.Red, MaterialTheme.shapes.small),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(emoji, fontSize = 14.sp)
+                }
+                Spacer(modifier = Modifier.width(4.dp))
+            }
+        }
     }
 }
 
@@ -82,10 +103,25 @@ fun GameScreen(
     val lobbyCode = lobbyState?.lobbyCode
     val validPositions by viewModel.validPositions.collectAsState()
     var gameOverWinner by remember { mutableStateOf<String?>(null) }
+    var showRoundResult by remember { mutableStateOf(false) }
+    var showFinalResult by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         viewModel.gameOverEvents.collect { winner -> gameOverWinner = winner }
     }
+
+    LaunchedEffect(Unit) {
+        viewModel.roundResultScreenRequested.collect {
+            showRoundResult = true
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.finalResultScreenRequested.collect {
+            showFinalResult = true
+        }
+    }
+
     LaunchedEffect(localPlayerId, lobbyCode) {
         if (localPlayerId != null && lobbyCode != null) {
             viewModel.initGameSession(lobbyCode, localPlayerId!!)
@@ -98,7 +134,6 @@ fun GameScreen(
             uiState.gameState.currentPlayerId == uiState.localPlayerId &&
             !uiState.isSyncing
 
-    // Hardware-Integration (Eigene Taschenlampe) - Refactored for Lifecycle & Type Safety
     val context = LocalContext.current
     val cameraManager = remember { context.getSystemService(Context.CAMERA_SERVICE) as CameraManager }
     val currentIsMyTurn by rememberUpdatedState(isMyTurn)
@@ -326,6 +361,32 @@ fun GameScreen(
                 onDismiss = {
                     showToolDialog = false
                     pendingToolSelection = null
+                }
+            )
+        }
+
+        if (showRoundResult && uiState.gameState.lastRoundResult != null) {
+            RoundResultScreen(
+                roundResult = uiState.gameState.lastRoundResult!!,
+                players = uiState.gameState.players,
+                onNextRound = {
+                    showRoundResult = false
+                }
+            )
+        }
+
+        if (showFinalResult && uiState.gameState.lastRoundResult != null) {
+            FinalResultScreen(
+                roundResult = uiState.gameState.lastRoundResult!!,
+                players = uiState.gameState.players,
+                onNewGame = {
+                    showFinalResult = false
+                    onBackToLobby()
+                },
+                onLeaveGame = {
+                    showFinalResult = false
+                    lobbyViewModel.leaveLobby()
+                    onBackToLobby()
                 }
             )
         }

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -25,9 +25,6 @@ import com.aau.saboteur.model.*
 import com.aau.saboteur.ui.components.*
 import com.aau.saboteur.viewModels.GameViewModel
 import com.aau.saboteur.viewModels.LobbyViewModel
-import com.aau.saboteur.ui.screens.RoundResultScreen
-import com.aau.saboteur.ui.screens.FinalResultScreen
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.unit.sp
 

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/GameScreen.kt
@@ -91,6 +91,7 @@ private fun ToolIcons(blockedTools: Set<ToolType>) {
 fun GameScreen(
     lobbyViewModel: LobbyViewModel,
     onBackToLobby: () -> Unit = {},
+    onBackToActiveLobby: () -> Unit = {},
     viewModel: GameViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -370,14 +371,9 @@ fun GameScreen(
             FinalResultScreen(
                 roundResult = uiState.gameState.lastRoundResult!!,
                 players = uiState.gameState.players,
-                onNewGame = {
+                onBackToLobby = {
                     showFinalResult = false
-                    onBackToLobby()
-                },
-                onLeaveGame = {
-                    showFinalResult = false
-                    lobbyViewModel.leaveLobby()
-                    onBackToLobby()
+                    onBackToActiveLobby()
                 }
             )
         }

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/RoundResultScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/RoundResultScreen.kt
@@ -111,10 +111,21 @@ fun RoundResultScreen(
 
                     players.forEach { player ->
                         val revealedRole = roundResult.revealedRoles[player.playerId]
-                        val roleIcon = if (revealedRole == Role.GOLDDIGGER) "⛏️" else "🔴"
-                        val roleText = if (revealedRole == Role.GOLDDIGGER) "Goldsucher" else "Saboteur"
-                        val roleColor = if (revealedRole == Role.GOLDDIGGER)
-                            OreGold else Color(0xFFD32F2F)
+                        val roleIcon = when (revealedRole) {
+                            Role.GOLDDIGGER -> "⛏️"
+                            Role.SABOTEUR -> "🔴"
+                            null -> "❓"
+                        }
+                        val roleText = when (revealedRole) {
+                            Role.GOLDDIGGER -> "Goldsucher"
+                            Role.SABOTEUR -> "Saboteur"
+                            null -> "Unbekannt"
+                        }
+                        val roleColor = when (revealedRole) {
+                            Role.GOLDDIGGER -> OreGold
+                            Role.SABOTEUR -> Color(0xFFD32F2F)
+                            null -> Color.Gray
+                        }
 
                         Surface(
                             modifier = Modifier.fillMaxWidth(),

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/RoundResultScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/RoundResultScreen.kt
@@ -1,0 +1,180 @@
+package com.aau.saboteur.ui.screens
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.aau.saboteur.model.PlayerTurn
+import com.aau.saboteur.model.Role
+import com.aau.saboteur.model.RoundResult
+import com.aau.saboteur.ui.theme.OreGold
+
+@Composable
+fun RoundResultScreen(
+    roundResult: RoundResult,
+    players: List<PlayerTurn>,
+    onNextRound: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .wrapContentHeight(),
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            border = BorderStroke(2.dp, OreGold),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+
+                Text(
+                    text = "Runde ${roundResult.roundNumber} beendet",
+                    style = MaterialTheme.typography.headlineMedium.copy(
+                        fontSize = 28.sp,
+                        fontWeight = FontWeight.ExtraBold,
+                        fontFamily = FontFamily.SansSerif
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                    maxLines = 1
+                )
+
+
+                val winnerColor = if (roundResult.winnerRole == Role.GOLDDIGGER)
+                    OreGold else Color(0xFFD32F2F)
+                val winnerIcon = if (roundResult.winnerRole == Role.GOLDDIGGER) "⛏️" else "🔴"
+                val winnerText = if (roundResult.winnerRole == Role.GOLDDIGGER)
+                    "Goldsucher gewinnen" else "Saboteure gewinnen"
+
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    color = winnerColor.copy(alpha = 0.2f),
+                    border = BorderStroke(1.dp, winnerColor)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(winnerIcon, fontSize = 20.sp)
+                        Spacer(Modifier.width(8.dp))
+                        Text(
+                            text = winnerText,
+                            style = MaterialTheme.typography.titleMedium.copy(
+                                fontWeight = FontWeight.Bold,
+                                fontFamily = FontFamily.SansSerif
+                            ),
+                            color = winnerColor
+                        )
+                    }
+                }
+
+
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = "Rollen dieser Runde",
+                        style = MaterialTheme.typography.labelMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = FontFamily.SansSerif
+                        ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    players.forEach { player ->
+                        val revealedRole = roundResult.revealedRoles[player.playerId]
+                        val roleIcon = if (revealedRole == Role.GOLDDIGGER) "⛏️" else "🔴"
+                        val roleText = if (revealedRole == Role.GOLDDIGGER) "Goldsucher" else "Saboteur"
+                        val roleColor = if (revealedRole == Role.GOLDDIGGER)
+                            OreGold else Color(0xFFD32F2F)
+
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(8.dp),
+                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(12.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    Text(roleIcon, fontSize = 18.sp)
+                                    Text(
+                                        text = player.playerName,
+                                        style = MaterialTheme.typography.bodyMedium.copy(
+                                            fontFamily = FontFamily.SansSerif
+                                        ),
+                                        color = MaterialTheme.colorScheme.onSurface
+                                    )
+                                }
+                                Text(
+                                    text = roleText,
+                                    style = MaterialTheme.typography.bodyMedium.copy(
+                                        fontWeight = FontWeight.Bold,
+                                        fontFamily = FontFamily.SansSerif
+                                    ),
+                                    color = roleColor
+                                )
+                            }
+                        }
+                    }
+                }
+
+
+                Button(
+                    onClick = onNextRound,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    shape = RoundedCornerShape(8.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    )
+                ) {
+                    Text(
+                        "Weiter zur nächsten Runde",
+                        style = MaterialTheme.typography.titleSmall.copy(
+                            fontWeight = FontWeight.ExtraBold,
+                            fontFamily = FontFamily.SansSerif
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/RoundResultScreenPreview.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/RoundResultScreenPreview.kt
@@ -70,8 +70,7 @@ fun FinalResultScreenPreview() {
         FinalResultScreen(
             roundResult = mockRoundResult,
             players = mockPlayers,
-            onNewGame = {},
-            onLeaveGame = {}
+            onBackToLobby = {}
         )
     }
 }

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/RoundResultScreenPreview.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/RoundResultScreenPreview.kt
@@ -1,0 +1,77 @@
+package com.aau.saboteur.ui.screens
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.aau.saboteur.model.PlayerTurn
+import com.aau.saboteur.model.Role
+import com.aau.saboteur.model.RoundResult
+import com.aau.saboteur.ui.theme.SE2GameTheme
+
+@Preview(showBackground = true, widthDp = 1080, heightDp = 1920)
+@Composable
+fun RoundResultScreenPreview() {
+    val mockPlayers = listOf(
+        PlayerTurn(playerId = "1", playerName = "Stefan"),
+        PlayerTurn(playerId = "2", playerName = "Lukas"),
+        PlayerTurn(playerId = "3", playerName = "Chris")
+    )
+
+    val mockRoundResult = RoundResult(
+        roundNumber = 1,
+        winnerRole = Role.GOLDDIGGER,
+        winningPlayerIds = listOf("1", "3"),
+        revealedRoles = mapOf(
+            "1" to Role.GOLDDIGGER,
+            "2" to Role.SABOTEUR,
+            "3" to Role.GOLDDIGGER
+        ),
+        playerGoldTotals = mapOf(
+            "1" to 5,
+            "2" to 0,
+            "3" to 3
+        )
+    )
+
+    SE2GameTheme {
+        RoundResultScreen(
+            roundResult = mockRoundResult,
+            players = mockPlayers,
+            onNextRound = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 1080, heightDp = 1920)
+@Composable
+fun FinalResultScreenPreview() {
+    val mockPlayers = listOf(
+        PlayerTurn(playerId = "1", playerName = "Stefan"),
+        PlayerTurn(playerId = "2", playerName = "Lukas"),
+        PlayerTurn(playerId = "3", playerName = "Chris")
+    )
+
+    val mockRoundResult = RoundResult(
+        roundNumber = 3,
+        winnerRole = Role.GOLDDIGGER,
+        winningPlayerIds = listOf("1", "3"),
+        revealedRoles = mapOf(
+            "1" to Role.GOLDDIGGER,
+            "2" to Role.SABOTEUR,
+            "3" to Role.GOLDDIGGER
+        ),
+        playerGoldTotals = mapOf(
+            "1" to 12,
+            "2" to 5,
+            "3" to 10
+        )
+    )
+
+    SE2GameTheme {
+        FinalResultScreen(
+            roundResult = mockRoundResult,
+            players = mockPlayers,
+            onNewGame = {},
+            onLeaveGame = {}
+        )
+    }
+}

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -45,6 +45,12 @@ class GameViewModel : ViewModel() {
     private val _gameOverEvents = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 1)
     val gameOverEvents: SharedFlow<String> = _gameOverEvents.asSharedFlow()
 
+    private val _roundResultScreenRequested = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1)
+    val roundResultScreenRequested: SharedFlow<Unit> = _roundResultScreenRequested.asSharedFlow()
+
+    private val _finalResultScreenRequested = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1)
+    val finalResultScreenRequested: SharedFlow<Unit> = _finalResultScreenRequested.asSharedFlow()
+
     private val _validPositions = MutableStateFlow<List<BoardPosition>>(emptyList())
     val validPositions: StateFlow<List<BoardPosition>> = _validPositions.asStateFlow()
 
@@ -59,6 +65,7 @@ class GameViewModel : ViewModel() {
         observeGameOverEvents()
         observeValidPositions()
         observeMapResults()
+        observeRoundResults()
         if (_uiState.value.gameState.players.isEmpty()) {
             _uiState.update { it.copy(isSyncing = true) }
         }
@@ -143,6 +150,20 @@ class GameViewModel : ViewModel() {
                 _uiState.update { it.copy(lastMapResult = result) }
                 delay(5000)
                 _uiState.update { it.copy(lastMapResult = null) }
+            }
+        }
+    }
+
+    private fun observeRoundResults() {
+        viewModelScope.launch {
+            _uiState.collect { state ->
+                if (state.gameState.isRoundOver && state.gameState.lastRoundResult != null) {
+                    if (state.gameState.isGameOver) {
+                        _finalResultScreenRequested.tryEmit(Unit)
+                    } else {
+                        _roundResultScreenRequested.tryEmit(Unit)
+                    }
+                }
             }
         }
     }
@@ -292,5 +313,11 @@ class GameViewModel : ViewModel() {
 
     fun dismissMapResult() {
         _uiState.update { it.copy(lastMapResult = null) }
+    }
+
+    fun dismissRoundResult() {
+    }
+
+    fun dismissFinalResult() {
     }
 }

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -156,15 +156,18 @@ class GameViewModel : ViewModel() {
 
     private fun observeRoundResults() {
         viewModelScope.launch {
-            _uiState.collect { state ->
-                if (state.gameState.isRoundOver && state.gameState.lastRoundResult != null) {
-                    if (state.gameState.isGameOver) {
-                        _finalResultScreenRequested.tryEmit(Unit)
-                    } else {
-                        _roundResultScreenRequested.tryEmit(Unit)
+            _uiState
+                .map { it.gameState }
+                .distinctUntilChanged()
+                .collect { gameState ->
+                    if (gameState.isRoundOver && gameState.lastRoundResult != null) {
+                        if (gameState.isGameOver) {
+                            _finalResultScreenRequested.tryEmit(Unit)
+                        } else {
+                            _roundResultScreenRequested.tryEmit(Unit)
+                        }
                     }
                 }
-            }
         }
     }
 

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -63,7 +63,6 @@ class GameViewModel : ViewModel() {
         observeGameOverEvents()
         observeValidPositions()
         observeMapResults()
-        observeRoundResults()
         if (_uiState.value.gameState.players.isEmpty()) {
             _uiState.update { it.copy(isSyncing = true) }
         }
@@ -156,23 +155,6 @@ class GameViewModel : ViewModel() {
                 delay(5000)
                 _uiState.update { it.copy(lastMapResult = null) }
             }
-        }
-    }
-
-    private fun observeRoundResults() {
-        viewModelScope.launch {
-            _uiState
-                .map { it.gameState }
-                .distinctUntilChanged()
-                .collect { gameState ->
-                    if (gameState.lastRoundResult != null) {
-                        if (gameState.isGameOver) {
-                            _finalResultScreenRequested.tryEmit(Unit)
-                        } else {
-                            _roundResultScreenRequested.tryEmit(Unit)
-                        }
-                    }
-                }
         }
     }
 

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -128,7 +128,7 @@ class GameViewModel : ViewModel() {
 
     private fun observeGameOverEvents() {
         viewModelScope.launch {
-            GameApi.gameOverEvents.collect { winner ->
+            GameApi.gameOverEvents.collect {
                 val gameState = _uiState.value.gameState
                 if (gameState.lastRoundResult != null) {
                     if (gameState.isGameOver) {

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -42,8 +42,6 @@ class GameViewModel : ViewModel() {
     private val _uiState = MutableStateFlow(GameUiState())
     val uiState: StateFlow<GameUiState> = _uiState.asStateFlow()
 
-    private val _gameOverEvents = MutableSharedFlow<String>(replay = 0, extraBufferCapacity = 1)
-    val gameOverEvents: SharedFlow<String> = _gameOverEvents.asSharedFlow()
 
     private val _roundResultScreenRequested = MutableSharedFlow<Unit>(replay = 0, extraBufferCapacity = 1)
     val roundResultScreenRequested: SharedFlow<Unit> = _roundResultScreenRequested.asSharedFlow()
@@ -131,7 +129,14 @@ class GameViewModel : ViewModel() {
     private fun observeGameOverEvents() {
         viewModelScope.launch {
             GameApi.gameOverEvents.collect { winner ->
-                _gameOverEvents.tryEmit(winner)
+                val gameState = _uiState.value.gameState
+                if (gameState.lastRoundResult != null) {
+                    if (gameState.isGameOver) {
+                        _finalResultScreenRequested.tryEmit(Unit)
+                    } else {
+                        _roundResultScreenRequested.tryEmit(Unit)
+                    }
+                }
             }
         }
     }
@@ -160,7 +165,7 @@ class GameViewModel : ViewModel() {
                 .map { it.gameState }
                 .distinctUntilChanged()
                 .collect { gameState ->
-                    if (gameState.isRoundOver && gameState.lastRoundResult != null) {
+                    if (gameState.lastRoundResult != null) {
                         if (gameState.isGameOver) {
                             _finalResultScreenRequested.tryEmit(Unit)
                         } else {

--- a/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
+++ b/app/app/src/main/java/com/aau/saboteur/viewModels/GameViewModel.kt
@@ -315,9 +315,4 @@ class GameViewModel : ViewModel() {
         _uiState.update { it.copy(lastMapResult = null) }
     }
 
-    fun dismissRoundResult() {
-    }
-
-    fun dismissFinalResult() {
-    }
 }

--- a/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
+++ b/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
@@ -193,4 +193,299 @@ class GameViewModelTest {
         val state = viewModel.uiState.value
         assertNull(state.selectedCard)
     }
+    @Test
+    fun `selectCard with PATH card selects it`() = runTest {
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
+
+        val card = com.aau.saboteur.model.TunnelCard(
+            id = "path1",
+            type = com.aau.saboteur.model.CardType.PATH,
+            connections = setOf(com.aau.saboteur.model.Direction.LEFT, com.aau.saboteur.model.Direction.RIGHT)
+        )
+        viewModel.selectCard(card)
+        advanceUntilIdle()
+
+        assertEquals(card, viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `selectCard deselects when same card clicked again`() = runTest {
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
+
+        val card = com.aau.saboteur.model.TunnelCard(
+            id = "path1",
+            type = com.aau.saboteur.model.CardType.PATH,
+            connections = setOf(com.aau.saboteur.model.Direction.LEFT, com.aau.saboteur.model.Direction.RIGHT)
+        )
+
+        viewModel.selectCard(card)
+        advanceUntilIdle()
+        assertEquals(card, viewModel.uiState.value.selectedCard)
+
+        viewModel.selectCard(card)
+        advanceUntilIdle()
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `selectCard with BLOCK card sets pending special card`() = runTest {
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
+
+        val blockCard = com.aau.saboteur.model.TunnelCard(
+            id = "block1",
+            type = com.aau.saboteur.model.CardType.CART_RED,
+            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
+        )
+        viewModel.selectCard(blockCard)
+        advanceUntilIdle()
+
+        assertEquals(com.aau.saboteur.model.CardType.CART_RED, viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `selectCard with REPAIR card sets pending special card`() = runTest {
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
+
+        val repairCard = com.aau.saboteur.model.TunnelCard(
+            id = "repair1",
+            type = com.aau.saboteur.model.CardType.CART_GREEN,
+            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
+        )
+        viewModel.selectCard(repairCard)
+        advanceUntilIdle()
+
+        assertEquals(com.aau.saboteur.model.CardType.CART_GREEN, viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `selectCard with MAP card sets pending special card`() = runTest {
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
+
+        val mapCard = com.aau.saboteur.model.TunnelCard(
+            id = "map1",
+            type = com.aau.saboteur.model.CardType.MAPCARD,
+            connections = emptySet()
+        )
+        viewModel.selectCard(mapCard)
+        advanceUntilIdle()
+
+        assertEquals(com.aau.saboteur.model.CardType.MAPCARD, viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `selectCard with ROCKFALL card sets pending special card`() = runTest {
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
+
+        val rockfallCard = com.aau.saboteur.model.TunnelCard(
+            id = "rockfall1",
+            type = com.aau.saboteur.model.CardType.ROCKFALL,
+            connections = emptySet()
+        )
+        viewModel.selectCard(rockfallCard)
+        advanceUntilIdle()
+
+        assertEquals(com.aau.saboteur.model.CardType.ROCKFALL, viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `onCardRotated updates rotation state`() = runTest {
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
+
+        val card = com.aau.saboteur.model.TunnelCard(
+            id = "card1",
+            type = com.aau.saboteur.model.CardType.PATH,
+            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
+        )
+
+        viewModel.onCardRotated(card, true)
+        advanceUntilIdle()
+
+        assertEquals(true, viewModel.uiState.value.cardRotations[card.id])
+    }
+
+    @Test
+    fun `onBoardCellClicked plays PATH card`() = runTest {
+        val card = com.aau.saboteur.model.TunnelCard(
+            id = "path1",
+            type = com.aau.saboteur.model.CardType.PATH,
+            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
+        )
+        val gameState = GameState(
+            players = listOf(com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1)),
+            currentPlayerId = "p1"
+        )
+
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(gameState)
+        viewModel.selectCard(card)
+        advanceUntilIdle()
+
+        val position = com.aau.saboteur.model.BoardPosition(4, 5)
+        viewModel.onBoardCellClicked(position)
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `onBoardCellClicked with blocked player shows error`() = runTest {
+        val card = com.aau.saboteur.model.TunnelCard(
+            id = "path1",
+            type = com.aau.saboteur.model.CardType.PATH,
+            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
+        )
+        val gameState = GameState(
+            players = listOf(
+                com.aau.saboteur.model.PlayerTurn(
+                    "p1",
+                    "Player1",
+                    1,
+                    blockedTools = setOf(com.aau.saboteur.model.ToolType.PICKAXE)
+                )
+            ),
+            currentPlayerId = "p1"
+        )
+
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(gameState)
+        viewModel.selectCard(card)
+        advanceUntilIdle()
+
+        val position = com.aau.saboteur.model.BoardPosition(4, 5)
+        viewModel.onBoardCellClicked(position)
+        advanceUntilIdle()
+
+        assertEquals("Du bist blockiert und kannst keine Tunnel legen.", viewModel.uiState.value.errorMessage)
+    }
+
+    @Test
+    fun `onBoardCellClicked with MAP card plays it`() = runTest {
+        val mapCard = com.aau.saboteur.model.TunnelCard(
+            id = "map1",
+            type = com.aau.saboteur.model.CardType.MAPCARD,
+            connections = emptySet()
+        )
+        val gameState = GameState(
+            players = listOf(com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1)),
+            currentPlayerId = "p1"
+        )
+
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(gameState)
+        viewModel.selectCard(mapCard)
+        advanceUntilIdle()
+
+        val position = com.aau.saboteur.model.BoardPosition(4, 5)
+        viewModel.onBoardCellClicked(position)
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `onBoardCellClicked with ROCKFALL card plays it`() = runTest {
+        val rockfallCard = com.aau.saboteur.model.TunnelCard(
+            id = "rockfall1",
+            type = com.aau.saboteur.model.CardType.ROCKFALL,
+            connections = emptySet()
+        )
+        val gameState = GameState(
+            players = listOf(com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1)),
+            currentPlayerId = "p1"
+        )
+
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(gameState)
+        viewModel.selectCard(rockfallCard)
+        advanceUntilIdle()
+
+        val position = com.aau.saboteur.model.BoardPosition(4, 5)
+        viewModel.onBoardCellClicked(position)
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `discardSelectedCard removes card`() = runTest {
+        val card = com.aau.saboteur.model.TunnelCard(
+            id = "path1",
+            type = com.aau.saboteur.model.CardType.PATH,
+            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
+        )
+        val gameState = GameState(
+            players = listOf(com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1)),
+            currentPlayerId = "p1"
+        )
+
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(gameState)
+        viewModel.selectCard(card)
+        advanceUntilIdle()
+
+        viewModel.discardSelectedCard()
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `playBlockCardOnPlayer plays block card`() = runTest {
+        val blockCard = com.aau.saboteur.model.TunnelCard(
+            id = "block1",
+            type = com.aau.saboteur.model.CardType.CART_RED,
+            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
+        )
+        val gameState = GameState(
+            players = listOf(
+                com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1),
+                com.aau.saboteur.model.PlayerTurn("p2", "Player2", 2)
+            ),
+            currentPlayerId = "p1"
+        )
+
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(gameState)
+        viewModel.selectCard(blockCard)
+        advanceUntilIdle()
+
+        viewModel.playBlockCardOnPlayer("p2")
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `playRepairCardOnPlayer plays repair card`() = runTest {
+        val repairCard = com.aau.saboteur.model.TunnelCard(
+            id = "repair1",
+            type = com.aau.saboteur.model.CardType.CART_GREEN,
+            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
+        )
+        val gameState = GameState(
+            players = listOf(
+                com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1),
+                com.aau.saboteur.model.PlayerTurn("p2", "Player2", 2)
+            ),
+            currentPlayerId = "p1"
+        )
+
+        viewModel.initGameSession("LOBBY", "p1")
+        injectGameState(gameState)
+        viewModel.selectCard(repairCard)
+        advanceUntilIdle()
+
+        viewModel.playRepairCardOnPlayer("p2", "PICKAXE")
+        advanceUntilIdle()
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
 }

--- a/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
+++ b/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
@@ -1,0 +1,157 @@
+package com.aau.saboteur.viewModels
+
+import com.aau.saboteur.model.GameState
+import com.aau.saboteur.model.Role
+import com.aau.saboteur.model.RoundResult
+import com.aau.saboteur.network.game.GameApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [33])
+class GameViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var viewModel: GameViewModel
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = GameViewModel()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        GameApi.reset()
+    }
+
+    @Test
+    fun `initial state has no lobby or player set`() {
+        val state = viewModel.uiState.value
+        assertNull(state.localPlayerId)
+        assertNull(state.lobbyCode)
+        assertNull(state.errorMessage)
+        assertNull(state.selectedCard)
+    }
+
+    @Test
+    fun `initGameSession sets lobbyCode and localPlayerId`() {
+        viewModel.initGameSession("LOBBY42", "player1")
+        val state = viewModel.uiState.value
+        assertEquals("LOBBY42", state.lobbyCode)
+        assertEquals("player1", state.localPlayerId)
+    }
+
+    @Test
+    fun `setLocalPlayerId updates localPlayerId in state`() {
+        viewModel.setLocalPlayerId("player99")
+        assertEquals("player99", viewModel.uiState.value.localPlayerId)
+    }
+
+    @Test
+    fun `setLocalPlayerId with null clears localPlayerId`() {
+        viewModel.setLocalPlayerId("player99")
+        viewModel.setLocalPlayerId(null)
+        assertNull(viewModel.uiState.value.localPlayerId)
+    }
+
+    @Test
+    fun `setError stores message in state`() {
+        viewModel.setError("something went wrong")
+        assertEquals("something went wrong", viewModel.uiState.value.errorMessage)
+    }
+
+    @Test
+    fun `dismissMapResult clears lastMapResult`() {
+        viewModel.dismissMapResult()
+        assertNull(viewModel.uiState.value.lastMapResult)
+    }
+
+    @Test
+    fun `roundResultScreenRequested emits when round ends and game continues`() = runTest {
+        val roundResult = RoundResult(
+            roundNumber = 1,
+            winnerRole = Role.GOLDDIGGER,
+            winningPlayerIds = listOf("p1")
+        )
+        val collected = mutableListOf<Unit>()
+        val job = launch { viewModel.roundResultScreenRequested.collect { collected.add(it) } }
+
+        advanceUntilIdle()
+        injectGameState(GameState(isRoundOver = true, isGameOver = false, lastRoundResult = roundResult))
+        advanceUntilIdle()
+
+        assertTrue("roundResultScreenRequested should have emitted", collected.isNotEmpty())
+        job.cancel()
+    }
+
+    @Test
+    fun `finalResultScreenRequested emits when game ends`() = runTest {
+        val roundResult = RoundResult(
+            roundNumber = 3,
+            winnerRole = Role.SABOTEUR,
+            winningPlayerIds = listOf("p2"),
+            gameFinished = true
+        )
+        val collected = mutableListOf<Unit>()
+        val job = launch { viewModel.finalResultScreenRequested.collect { collected.add(it) } }
+
+        advanceUntilIdle()
+        injectGameState(GameState(isRoundOver = true, isGameOver = true, lastRoundResult = roundResult))
+        advanceUntilIdle()
+
+        assertTrue("finalResultScreenRequested should have emitted", collected.isNotEmpty())
+        job.cancel()
+    }
+
+    @Test
+    fun `roundResultScreenRequested does not emit when round is not over`() = runTest {
+        val collected = mutableListOf<Unit>()
+        val job = launch { viewModel.roundResultScreenRequested.collect { collected.add(it) } }
+
+        advanceUntilIdle()
+        injectGameState(GameState(isRoundOver = false))
+        advanceUntilIdle()
+
+        assertTrue("roundResultScreenRequested should not emit mid-round", collected.isEmpty())
+        job.cancel()
+    }
+
+    @Test
+    fun `roundResultScreenRequested does not emit when lastRoundResult is null`() = runTest {
+        val collected = mutableListOf<Unit>()
+        val job = launch { viewModel.roundResultScreenRequested.collect { collected.add(it) } }
+
+        advanceUntilIdle()
+        injectGameState(GameState(isRoundOver = true, lastRoundResult = null))
+        advanceUntilIdle()
+
+        assertTrue("roundResultScreenRequested should not emit without a result", collected.isEmpty())
+        job.cancel()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun injectGameState(gameState: GameState) {
+        val field = GameApi::class.java.getDeclaredField("_gameStateUpdates")
+        field.isAccessible = true
+        (field.get(GameApi) as MutableStateFlow<GameState>).value = gameState
+    }
+}

--- a/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
+++ b/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
@@ -572,4 +572,63 @@ class GameViewModelTest {
         assertEquals(card, viewModel.uiState.value.selectedCard)
     }
 
+    @Test
+    fun `onBoardCellClicked does nothing while syncing`() {
+        viewModel.initGameSession("LOBBY123", "p1")
+
+        val card = TunnelCard(
+            id = "path1",
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
+        )
+
+        viewModel.selectCard(card)
+        viewModel.onBoardCellClicked(BoardPosition(0, 0))
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `discardSelectedCard does nothing while syncing`() {
+        viewModel.initGameSession("LOBBY123", "p1")
+
+        viewModel.discardSelectedCard()
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `triggerCheat does nothing without lobbyCode`() {
+        viewModel.triggerCheat(CheatType.LANTERN_FLASHLIGHT)
+
+        assertNull(viewModel.uiState.value.lobbyCode)
+    }
+
+    @Test
+    fun `onBoardCellClicked with repair card on board shows error`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "repair1",
+            type = CardType.CART_GREEN,
+            connections = emptySet()
+        )
+
+        viewModel.selectCard(card)
+        viewModel.onBoardCellClicked(BoardPosition(0, 0))
+
+        assertEquals(
+            "Diese Karte kann hier nicht auf das Feld gespielt werden.",
+            viewModel.uiState.value.errorMessage
+        )
+    }
+
 }

--- a/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
+++ b/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
@@ -154,4 +154,43 @@ class GameViewModelTest {
         field.isAccessible = true
         (field.get(GameApi) as MutableStateFlow<GameState>).value = gameState
     }
+
+    @Test
+    fun `setLocalPlayerId updates state correctly`() {
+        viewModel.setLocalPlayerId("player123")
+        assertEquals("player123", viewModel.uiState.value.localPlayerId)
+    }
+
+    @Test
+    fun `initGameSession sets both lobbyCode and playerId`() {
+        viewModel.initGameSession("CODE456", "playerXYZ")
+        val state = viewModel.uiState.value
+        assertEquals("CODE456", state.lobbyCode)
+        assertEquals("playerXYZ", state.localPlayerId)
+    }
+
+    @Test
+    fun `setError stores error message in state`() {
+        val errorMsg = "Connection failed"
+        viewModel.setError(errorMsg)
+        assertEquals(errorMsg, viewModel.uiState.value.errorMessage)
+    }
+
+    @Test
+    fun `dismissMapResult clears lastMapResult from state`() {
+        viewModel.dismissMapResult()
+        assertNull(viewModel.uiState.value.lastMapResult)
+    }
+
+    @Test
+    fun `initial state has no errors`() {
+        val state = viewModel.uiState.value
+        assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun `initial state has selectedCard as null`() {
+        val state = viewModel.uiState.value
+        assertNull(state.selectedCard)
+    }
 }

--- a/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
+++ b/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
@@ -1,18 +1,12 @@
 package com.aau.saboteur.viewModels
 
-import com.aau.saboteur.model.GameState
-import com.aau.saboteur.model.Role
-import com.aau.saboteur.model.RoundResult
+import com.aau.saboteur.model.*
 import com.aau.saboteur.network.game.GameApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.*
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -43,6 +37,20 @@ class GameViewModelTest {
         GameApi.reset()
     }
 
+    private fun setupActiveSession() {
+        viewModel.initGameSession("LOBBY123", "p1")
+        // Inject a state with at least one player to clear isSyncing
+        injectGameState(GameState(players = listOf(PlayerTurn("p1", "Alice", 1))))
+        testDispatcher.scheduler.advanceUntilIdle()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun injectGameState(gameState: GameState) {
+        val field = GameApi::class.java.getDeclaredField("_gameStateUpdates")
+        field.isAccessible = true
+        (field.get(GameApi) as MutableStateFlow<GameState>).value = gameState
+    }
+
     @Test
     fun `initial state has no lobby or player set`() {
         val state = viewModel.uiState.value
@@ -64,13 +72,6 @@ class GameViewModelTest {
     fun `setLocalPlayerId updates localPlayerId in state`() {
         viewModel.setLocalPlayerId("player99")
         assertEquals("player99", viewModel.uiState.value.localPlayerId)
-    }
-
-    @Test
-    fun `setLocalPlayerId with null clears localPlayerId`() {
-        viewModel.setLocalPlayerId("player99")
-        viewModel.setLocalPlayerId(null)
-        assertNull(viewModel.uiState.value.localPlayerId)
     }
 
     @Test
@@ -123,369 +124,108 @@ class GameViewModelTest {
     }
 
     @Test
-    fun `roundResultScreenRequested does not emit when round is not over`() = runTest {
-        val collected = mutableListOf<Unit>()
-        val job = launch { viewModel.roundResultScreenRequested.collect { collected.add(it) } }
+    fun `selectCard updates selectedCard state`() {
+        setupActiveSession()
 
-        advanceUntilIdle()
-        injectGameState(GameState(isRoundOver = false))
-        advanceUntilIdle()
-
-        assertTrue("roundResultScreenRequested should not emit mid-round", collected.isEmpty())
-        job.cancel()
-    }
-
-    @Test
-    fun `roundResultScreenRequested does not emit when lastRoundResult is null`() = runTest {
-        val collected = mutableListOf<Unit>()
-        val job = launch { viewModel.roundResultScreenRequested.collect { collected.add(it) } }
-
-        advanceUntilIdle()
-        injectGameState(GameState(isRoundOver = true, lastRoundResult = null))
-        advanceUntilIdle()
-
-        assertTrue("roundResultScreenRequested should not emit without a result", collected.isEmpty())
-        job.cancel()
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun injectGameState(gameState: GameState) {
-        val field = GameApi::class.java.getDeclaredField("_gameStateUpdates")
-        field.isAccessible = true
-        (field.get(GameApi) as MutableStateFlow<GameState>).value = gameState
-    }
-
-    @Test
-    fun `setLocalPlayerId updates state correctly`() {
-        viewModel.setLocalPlayerId("player123")
-        assertEquals("player123", viewModel.uiState.value.localPlayerId)
-    }
-
-    @Test
-    fun `initGameSession sets both lobbyCode and playerId`() {
-        viewModel.initGameSession("CODE456", "playerXYZ")
-        val state = viewModel.uiState.value
-        assertEquals("CODE456", state.lobbyCode)
-        assertEquals("playerXYZ", state.localPlayerId)
-    }
-
-    @Test
-    fun `setError stores error message in state`() {
-        val errorMsg = "Connection failed"
-        viewModel.setError(errorMsg)
-        assertEquals(errorMsg, viewModel.uiState.value.errorMessage)
-    }
-
-    @Test
-    fun `dismissMapResult clears lastMapResult from state`() {
-        viewModel.dismissMapResult()
-        assertNull(viewModel.uiState.value.lastMapResult)
-    }
-
-    @Test
-    fun `initial state has no errors`() {
-        val state = viewModel.uiState.value
-        assertNull(state.errorMessage)
-    }
-
-    @Test
-    fun `initial state has selectedCard as null`() {
-        val state = viewModel.uiState.value
-        assertNull(state.selectedCard)
-    }
-    @Test
-    fun `selectCard with PATH card selects it`() = runTest {
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
-
-        val card = com.aau.saboteur.model.TunnelCard(
+        val card = TunnelCard(
             id = "path1",
-            type = com.aau.saboteur.model.CardType.PATH,
-            connections = setOf(com.aau.saboteur.model.Direction.LEFT, com.aau.saboteur.model.Direction.RIGHT)
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
         )
-        viewModel.selectCard(card)
-        advanceUntilIdle()
 
+        viewModel.selectCard(card)
         assertEquals(card, viewModel.uiState.value.selectedCard)
     }
 
     @Test
-    fun `selectCard deselects when same card clicked again`() = runTest {
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
+    fun `selectCard clears selectedCard when clicked again`() {
+        setupActiveSession()
 
-        val card = com.aau.saboteur.model.TunnelCard(
+        val card = TunnelCard(
             id = "path1",
-            type = com.aau.saboteur.model.CardType.PATH,
-            connections = setOf(com.aau.saboteur.model.Direction.LEFT, com.aau.saboteur.model.Direction.RIGHT)
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
         )
 
         viewModel.selectCard(card)
-        advanceUntilIdle()
         assertEquals(card, viewModel.uiState.value.selectedCard)
 
         viewModel.selectCard(card)
-        advanceUntilIdle()
         assertNull(viewModel.uiState.value.selectedCard)
     }
 
     @Test
-    fun `selectCard with BLOCK card sets pending special card`() = runTest {
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
+    fun `onCardRotated updates cardRotations map`() {
+        setupActiveSession()
 
-        val blockCard = com.aau.saboteur.model.TunnelCard(
-            id = "block1",
-            type = com.aau.saboteur.model.CardType.CART_RED,
-            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
-        )
-        viewModel.selectCard(blockCard)
-        advanceUntilIdle()
-
-        assertEquals(com.aau.saboteur.model.CardType.CART_RED, viewModel.uiState.value.pendingSpecialCard)
-    }
-
-    @Test
-    fun `selectCard with REPAIR card sets pending special card`() = runTest {
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
-
-        val repairCard = com.aau.saboteur.model.TunnelCard(
-            id = "repair1",
-            type = com.aau.saboteur.model.CardType.CART_GREEN,
-            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
-        )
-        viewModel.selectCard(repairCard)
-        advanceUntilIdle()
-
-        assertEquals(com.aau.saboteur.model.CardType.CART_GREEN, viewModel.uiState.value.pendingSpecialCard)
-    }
-
-    @Test
-    fun `selectCard with MAP card sets pending special card`() = runTest {
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
-
-        val mapCard = com.aau.saboteur.model.TunnelCard(
-            id = "map1",
-            type = com.aau.saboteur.model.CardType.MAPCARD,
-            connections = emptySet()
-        )
-        viewModel.selectCard(mapCard)
-        advanceUntilIdle()
-
-        assertEquals(com.aau.saboteur.model.CardType.MAPCARD, viewModel.uiState.value.pendingSpecialCard)
-    }
-
-    @Test
-    fun `selectCard with ROCKFALL card sets pending special card`() = runTest {
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
-
-        val rockfallCard = com.aau.saboteur.model.TunnelCard(
-            id = "rockfall1",
-            type = com.aau.saboteur.model.CardType.ROCKFALL,
-            connections = emptySet()
-        )
-        viewModel.selectCard(rockfallCard)
-        advanceUntilIdle()
-
-        assertEquals(com.aau.saboteur.model.CardType.ROCKFALL, viewModel.uiState.value.pendingSpecialCard)
-    }
-
-    @Test
-    fun `onCardRotated updates rotation state`() = runTest {
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(GameState(players = emptyList(), currentPlayerId = "p1"))
-
-        val card = com.aau.saboteur.model.TunnelCard(
+        val card = TunnelCard(
             id = "card1",
-            type = com.aau.saboteur.model.CardType.PATH,
-            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
         )
 
         viewModel.onCardRotated(card, true)
-        advanceUntilIdle()
-
         assertEquals(true, viewModel.uiState.value.cardRotations[card.id])
     }
 
     @Test
-    fun `onBoardCellClicked plays PATH card`() = runTest {
-        val card = com.aau.saboteur.model.TunnelCard(
-            id = "path1",
-            type = com.aau.saboteur.model.CardType.PATH,
-            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
-        )
-        val gameState = GameState(
-            players = listOf(com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1)),
-            currentPlayerId = "p1"
-        )
+    fun `selectCard with BLOCK card sets pending card type`() {
+        setupActiveSession()
 
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(gameState)
-        viewModel.selectCard(card)
-        advanceUntilIdle()
-
-        val position = com.aau.saboteur.model.BoardPosition(4, 5)
-        viewModel.onBoardCellClicked(position)
-        advanceUntilIdle()
-
-        assertNull(viewModel.uiState.value.selectedCard)
-    }
-
-    @Test
-    fun `onBoardCellClicked with blocked player shows error`() = runTest {
-        val card = com.aau.saboteur.model.TunnelCard(
-            id = "path1",
-            type = com.aau.saboteur.model.CardType.PATH,
-            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
-        )
-        val gameState = GameState(
-            players = listOf(
-                com.aau.saboteur.model.PlayerTurn(
-                    "p1",
-                    "Player1",
-                    1,
-                    blockedTools = setOf(com.aau.saboteur.model.ToolType.PICKAXE)
-                )
-            ),
-            currentPlayerId = "p1"
-        )
-
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(gameState)
-        viewModel.selectCard(card)
-        advanceUntilIdle()
-
-        val position = com.aau.saboteur.model.BoardPosition(4, 5)
-        viewModel.onBoardCellClicked(position)
-        advanceUntilIdle()
-
-        assertEquals("Du bist blockiert und kannst keine Tunnel legen.", viewModel.uiState.value.errorMessage)
-    }
-
-    @Test
-    fun `onBoardCellClicked with MAP card plays it`() = runTest {
-        val mapCard = com.aau.saboteur.model.TunnelCard(
-            id = "map1",
-            type = com.aau.saboteur.model.CardType.MAPCARD,
-            connections = emptySet()
-        )
-        val gameState = GameState(
-            players = listOf(com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1)),
-            currentPlayerId = "p1"
-        )
-
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(gameState)
-        viewModel.selectCard(mapCard)
-        advanceUntilIdle()
-
-        val position = com.aau.saboteur.model.BoardPosition(4, 5)
-        viewModel.onBoardCellClicked(position)
-        advanceUntilIdle()
-
-        assertNull(viewModel.uiState.value.selectedCard)
-    }
-
-    @Test
-    fun `onBoardCellClicked with ROCKFALL card plays it`() = runTest {
-        val rockfallCard = com.aau.saboteur.model.TunnelCard(
-            id = "rockfall1",
-            type = com.aau.saboteur.model.CardType.ROCKFALL,
-            connections = emptySet()
-        )
-        val gameState = GameState(
-            players = listOf(com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1)),
-            currentPlayerId = "p1"
-        )
-
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(gameState)
-        viewModel.selectCard(rockfallCard)
-        advanceUntilIdle()
-
-        val position = com.aau.saboteur.model.BoardPosition(4, 5)
-        viewModel.onBoardCellClicked(position)
-        advanceUntilIdle()
-
-        assertNull(viewModel.uiState.value.selectedCard)
-    }
-
-    @Test
-    fun `discardSelectedCard removes card`() = runTest {
-        val card = com.aau.saboteur.model.TunnelCard(
-            id = "path1",
-            type = com.aau.saboteur.model.CardType.PATH,
-            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
-        )
-        val gameState = GameState(
-            players = listOf(com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1)),
-            currentPlayerId = "p1"
-        )
-
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(gameState)
-        viewModel.selectCard(card)
-        advanceUntilIdle()
-
-        viewModel.discardSelectedCard()
-        advanceUntilIdle()
-
-        assertNull(viewModel.uiState.value.selectedCard)
-    }
-
-    @Test
-    fun `playBlockCardOnPlayer plays block card`() = runTest {
-        val blockCard = com.aau.saboteur.model.TunnelCard(
+        val blockCard = TunnelCard(
             id = "block1",
-            type = com.aau.saboteur.model.CardType.CART_RED,
-            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
-        )
-        val gameState = GameState(
-            players = listOf(
-                com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1),
-                com.aau.saboteur.model.PlayerTurn("p2", "Player2", 2)
-            ),
-            currentPlayerId = "p1"
+            type = CardType.CART_RED,
+            connections = setOf(Direction.LEFT)
         )
 
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(gameState)
         viewModel.selectCard(blockCard)
-        advanceUntilIdle()
-
-        viewModel.playBlockCardOnPlayer("p2")
-        advanceUntilIdle()
-
-        assertNull(viewModel.uiState.value.selectedCard)
+        assertEquals(CardType.CART_RED, viewModel.uiState.value.pendingSpecialCard)
     }
 
     @Test
-    fun `playRepairCardOnPlayer plays repair card`() = runTest {
-        val repairCard = com.aau.saboteur.model.TunnelCard(
+    fun `selectCard with REPAIR card sets pending card type`() {
+        setupActiveSession()
+
+        val repairCard = TunnelCard(
             id = "repair1",
-            type = com.aau.saboteur.model.CardType.CART_GREEN,
-            connections = setOf(com.aau.saboteur.model.Direction.LEFT)
-        )
-        val gameState = GameState(
-            players = listOf(
-                com.aau.saboteur.model.PlayerTurn("p1", "Player1", 1),
-                com.aau.saboteur.model.PlayerTurn("p2", "Player2", 2)
-            ),
-            currentPlayerId = "p1"
+            type = CardType.CART_GREEN,
+            connections = setOf(Direction.LEFT)
         )
 
-        viewModel.initGameSession("LOBBY", "p1")
-        injectGameState(gameState)
         viewModel.selectCard(repairCard)
-        advanceUntilIdle()
-
-        viewModel.playRepairCardOnPlayer("p2", "PICKAXE")
-        advanceUntilIdle()
-
-        assertNull(viewModel.uiState.value.selectedCard)
+        assertEquals(CardType.CART_GREEN, viewModel.uiState.value.pendingSpecialCard)
     }
 
+    @Test
+    fun `selectCard with MAP card sets pending card type`() {
+        setupActiveSession()
+
+        val mapCard = TunnelCard(
+            id = "map1",
+            type = CardType.MAPCARD,
+            connections = emptySet()
+        )
+
+        viewModel.selectCard(mapCard)
+        assertEquals(CardType.MAPCARD, viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `selectCard with ROCKFALL card sets pending card type`() {
+        setupActiveSession()
+
+        val rockfallCard = TunnelCard(
+            id = "rockfall1",
+            type = CardType.ROCKFALL,
+            connections = emptySet()
+        )
+
+        viewModel.selectCard(rockfallCard)
+        assertEquals(CardType.ROCKFALL, viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `valid positions state is initialized empty`() {
+        assertTrue(viewModel.validPositions.value.isEmpty())
+    }
 }

--- a/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
+++ b/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
@@ -228,4 +228,348 @@ class GameViewModelTest {
     fun `valid positions state is initialized empty`() {
         assertTrue(viewModel.validPositions.value.isEmpty())
     }
+
+    @Test
+    fun `game state update sets remaining deck size and clears syncing`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1",
+                deckSize = 24
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(24, viewModel.uiState.value.remainingDeckSize)
+        assertEquals("p1", viewModel.uiState.value.gameState.currentPlayerId)
+    }
+
+    @Test
+    fun `selectCard does nothing when no lobbyCode is set`() {
+        val card = TunnelCard(
+            id = "path1",
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
+        )
+
+        viewModel.selectCard(card)
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `selectCard does nothing while syncing`() {
+        viewModel.initGameSession("LOBBY123", "p1")
+
+        val card = TunnelCard(
+            id = "path1",
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
+        )
+
+        viewModel.selectCard(card)
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `onCardRotated updates selectedCardRotated when selected card is rotated`() {
+        setupActiveSession()
+
+        val card = TunnelCard(
+            id = "path1",
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
+        )
+
+        viewModel.selectCard(card)
+        viewModel.onCardRotated(card, true)
+
+        assertEquals(true, viewModel.uiState.value.selectedCardRotated)
+    }
+
+    @Test
+    fun `selectCard uses saved rotation when card is selected again`() {
+        setupActiveSession()
+
+        val card = TunnelCard(
+            id = "path1",
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
+        )
+
+        viewModel.onCardRotated(card, true)
+        viewModel.selectCard(card)
+
+        assertEquals(true, viewModel.uiState.value.selectedCardRotated)
+    }
+
+    @Test
+    fun `discardSelectedCard clears selected card when it is current players turn`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "path1",
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
+        )
+
+        viewModel.selectCard(card)
+        viewModel.discardSelectedCard()
+
+        assertNull(viewModel.uiState.value.selectedCard)
+        assertNull(viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `discardSelectedCard does nothing when it is not current players turn`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p2"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "path1",
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
+        )
+
+        viewModel.selectCard(card)
+        viewModel.discardSelectedCard()
+
+        assertEquals(card, viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `onBoardCellClicked clears selected card after playing path card`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "path1",
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
+        )
+
+        viewModel.selectCard(card)
+        viewModel.onBoardCellClicked(BoardPosition(0, 0))
+
+        assertNull(viewModel.uiState.value.selectedCard)
+        assertNull(viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `onBoardCellClicked does nothing when no selected card exists`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        viewModel.onBoardCellClicked(BoardPosition(0, 0))
+
+        assertNull(viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `onBoardCellClicked with map card clears selected card`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "map1",
+            type = CardType.MAPCARD,
+            connections = emptySet()
+        )
+
+        viewModel.selectCard(card)
+        viewModel.onBoardCellClicked(BoardPosition(1, 1))
+
+        assertNull(viewModel.uiState.value.selectedCard)
+        assertNull(viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `onBoardCellClicked with rockfall card clears selected card`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "rockfall1",
+            type = CardType.ROCKFALL,
+            connections = emptySet()
+        )
+
+        viewModel.selectCard(card)
+        viewModel.onBoardCellClicked(BoardPosition(1, 1))
+
+        assertNull(viewModel.uiState.value.selectedCard)
+        assertNull(viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `onBoardCellClicked with block card on board shows error`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "block1",
+            type = CardType.CART_RED,
+            connections = emptySet()
+        )
+
+        viewModel.selectCard(card)
+        viewModel.onBoardCellClicked(BoardPosition(0, 0))
+
+        assertEquals(
+            "Diese Karte kann hier nicht auf das Feld gespielt werden.",
+            viewModel.uiState.value.errorMessage
+        )
+    }
+
+    @Test
+    fun `playBlockCardOnPlayer clears selected block card`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "block1",
+            type = CardType.CART_RED,
+            connections = emptySet()
+        )
+
+        viewModel.selectCard(card)
+        viewModel.playBlockCardOnPlayer("p2")
+
+        assertNull(viewModel.uiState.value.selectedCard)
+        assertNull(viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `playRepairCardOnPlayer clears selected repair card`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "repair1",
+            type = CardType.CART_GREEN,
+            connections = emptySet()
+        )
+
+        viewModel.selectCard(card)
+        viewModel.playRepairCardOnPlayer("p2", "cart")
+
+        assertNull(viewModel.uiState.value.selectedCard)
+        assertNull(viewModel.uiState.value.pendingSpecialCard)
+    }
+
+    @Test
+    fun `playBlockCardOnPlayer does nothing with non block card`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "path1",
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
+        )
+
+        viewModel.selectCard(card)
+        viewModel.playBlockCardOnPlayer("p2")
+
+        assertEquals(card, viewModel.uiState.value.selectedCard)
+    }
+
+    @Test
+    fun `playRepairCardOnPlayer does nothing with non repair card`() {
+        setupActiveSession()
+
+        injectGameState(
+            GameState(
+                players = listOf(PlayerTurn("p1", "Alice", 1)),
+                currentPlayerId = "p1"
+            )
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val card = TunnelCard(
+            id = "path1",
+            type = CardType.PATH,
+            connections = setOf(Direction.LEFT)
+        )
+
+        viewModel.selectCard(card)
+        viewModel.playRepairCardOnPlayer("p2", "cart")
+
+        assertEquals(card, viewModel.uiState.value.selectedCard)
+    }
+
 }

--- a/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
+++ b/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
@@ -87,42 +87,6 @@ class GameViewModelTest {
         assertNull(viewModel.uiState.value.lastMapResult)
     }
 
-    @Test
-    fun `roundResultScreenRequested emits when round ends and game continues`() = runTest {
-        val roundResult = RoundResult(
-            roundNumber = 1,
-            winnerRole = Role.GOLDDIGGER,
-            winningPlayerIds = listOf("p1")
-        )
-        val collected = mutableListOf<Unit>()
-        val job = launch { viewModel.roundResultScreenRequested.collect { collected.add(it) } }
-
-        advanceUntilIdle()
-        injectGameState(GameState(isRoundOver = true, isGameOver = false, lastRoundResult = roundResult))
-        advanceUntilIdle()
-
-        assertTrue("roundResultScreenRequested should have emitted", collected.isNotEmpty())
-        job.cancel()
-    }
-
-    @Test
-    fun `finalResultScreenRequested emits when game ends`() = runTest {
-        val roundResult = RoundResult(
-            roundNumber = 3,
-            winnerRole = Role.SABOTEUR,
-            winningPlayerIds = listOf("p2"),
-            gameFinished = true
-        )
-        val collected = mutableListOf<Unit>()
-        val job = launch { viewModel.finalResultScreenRequested.collect { collected.add(it) } }
-
-        advanceUntilIdle()
-        injectGameState(GameState(isRoundOver = true, isGameOver = true, lastRoundResult = roundResult))
-        advanceUntilIdle()
-
-        assertTrue("finalResultScreenRequested should have emitted", collected.isNotEmpty())
-        job.cancel()
-    }
 
     @Test
     fun `selectCard updates selectedCard state`() {

--- a/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
+++ b/app/app/src/test/java/com/aau/saboteur/viewModels/GameViewModelTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import kotlinx.coroutines.flow.MutableSharedFlow
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -629,6 +630,64 @@ class GameViewModelTest {
             "Diese Karte kann hier nicht auf das Feld gespielt werden.",
             viewModel.uiState.value.errorMessage
         )
+    }
+
+    @Test
+    fun `observeGameOverEvents emits roundResultScreenRequested on GAME_OVER when round is not final`() = runTest {
+        val roundResult = RoundResult(roundNumber = 1, winnerRole = Role.GOLDDIGGER, winningPlayerIds = listOf("p1"))
+        injectGameState(GameState(isRoundOver = true, isGameOver = false, lastRoundResult = roundResult))
+
+        val collected = mutableListOf<Unit>()
+        val job = launch { viewModel.roundResultScreenRequested.collect { collected.add(it) } }
+
+        advanceUntilIdle()
+        injectGameOverEvent("DWARVES")
+        advanceUntilIdle()
+
+        assertTrue("roundResultScreenRequested should emit on GAME_OVER with non-final round", collected.isNotEmpty())
+        job.cancel()
+    }
+
+    @Test
+    fun `observeGameOverEvents emits finalResultScreenRequested on GAME_OVER when game is over`() = runTest {
+        val roundResult = RoundResult(roundNumber = 3, winnerRole = Role.GOLDDIGGER, gameFinished = true)
+        injectGameState(GameState(isRoundOver = true, isGameOver = true, lastRoundResult = roundResult))
+
+        val collected = mutableListOf<Unit>()
+        val job = launch { viewModel.finalResultScreenRequested.collect { collected.add(it) } }
+
+        advanceUntilIdle()
+        injectGameOverEvent("DWARVES")
+        advanceUntilIdle()
+
+        assertTrue("finalResultScreenRequested should emit on GAME_OVER when isGameOver=true", collected.isNotEmpty())
+        job.cancel()
+    }
+
+    @Test
+    fun `observeGameOverEvents does nothing on GAME_OVER when lastRoundResult is null`() = runTest {
+        injectGameState(GameState(isRoundOver = true, isGameOver = false, lastRoundResult = null))
+
+        val roundCollected = mutableListOf<Unit>()
+        val finalCollected = mutableListOf<Unit>()
+        val job1 = launch { viewModel.roundResultScreenRequested.collect { roundCollected.add(it) } }
+        val job2 = launch { viewModel.finalResultScreenRequested.collect { finalCollected.add(it) } }
+
+        advanceUntilIdle()
+        injectGameOverEvent("DWARVES")
+        advanceUntilIdle()
+
+        assertTrue("No screen should be requested when lastRoundResult is null", roundCollected.isEmpty())
+        assertTrue("No screen should be requested when lastRoundResult is null", finalCollected.isEmpty())
+        job1.cancel()
+        job2.cancel()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun injectGameOverEvent(winner: String) {
+        val field = GameApi::class.java.getDeclaredField("_gameOverEvents")
+        field.isAccessible = true
+        (field.get(GameApi) as MutableSharedFlow<String>).tryEmit(winner)
     }
 
 }

--- a/app/gradle/libs.versions.toml
+++ b/app/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ mockwebserver = "4.12.0"
 okhttp = "4.12.0"
 serialization = "1.7.3"
 robolectricVersion = "4.15"
+coroutines = "1.8.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,6 +35,7 @@ mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", versio
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectricVersion" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/server/src/main/kotlin/com/aau/server/service/LobbyService.kt
+++ b/server/src/main/kotlin/com/aau/server/service/LobbyService.kt
@@ -140,6 +140,17 @@ class LobbyService(
     }
 
     @Transactional
+    fun resetAfterGame(code: String) {
+        logger.info("Resetting lobby after game: {}", code)
+        val lobby = lobbies[code] ?: return
+        val updatedLobby = lobby.copy(gameStarted = false)
+        lobbies[code] = updatedLobby
+        turnManager.removeGame(code)
+        gameService.removePlayerData(code)
+        persist(updatedLobby)
+    }
+
+    @Transactional
     fun deleteLobbyInternal(code: String, reason: String) {
         logger.info("Cleaning up {} lobby: {}", reason, code)
 

--- a/server/src/main/kotlin/com/aau/server/websocket/command/handlers/DiscardCardHandler.kt
+++ b/server/src/main/kotlin/com/aau/server/websocket/command/handlers/DiscardCardHandler.kt
@@ -45,7 +45,7 @@ class DiscardCardHandler(
             if (result.winner != null) {
                 messagingService.sendEventToLobby(lobbyCode, GameEvent.GameOver(result.winner))
                 if (result.updatedGameState.isGameOver) {
-                    lobbyService.deleteLobbyInternal(lobbyCode, "game_over")
+                    lobbyService.resetAfterGame(lobbyCode)
                 }
             }
         }

--- a/server/src/main/kotlin/com/aau/server/websocket/command/handlers/DiscardCardHandler.kt
+++ b/server/src/main/kotlin/com/aau/server/websocket/command/handlers/DiscardCardHandler.kt
@@ -41,11 +41,12 @@ class DiscardCardHandler(
 
             messagingService.sendEventToLobby(lobbyCode, GameEvent.GameStateUpdate(result.updatedGameState))
             messagingService.sendEventToLobby(lobbyCode, GameEvent.CardsDealt(result.updatedHands))
-            
+
             if (result.winner != null) {
                 messagingService.sendEventToLobby(lobbyCode, GameEvent.GameOver(result.winner))
-                // Clean up lobby after game over so players aren't "pulled back" into a finished game
-                lobbyService.deleteLobbyInternal(lobbyCode, "game_over")
+                if (result.updatedGameState.isGameOver) {
+                    lobbyService.deleteLobbyInternal(lobbyCode, "game_over")
+                }
             }
         }
     }

--- a/server/src/main/kotlin/com/aau/server/websocket/command/handlers/PlayCardHandler.kt
+++ b/server/src/main/kotlin/com/aau/server/websocket/command/handlers/PlayCardHandler.kt
@@ -24,7 +24,7 @@ class PlayCardHandler(
     override fun handle(session: WebSocketSession, command: PlayCardCommand) {
         val lobbyCode = messagingService.getLobbyCodeForSession(session.id)
             ?: throw IllegalArgumentException("Session ist mit keiner Lobby verbunden")
-        
+
         // Final Fix: Sequential processing per lobby
         messagingService.getLobbyLock(lobbyCode).withLock {
             val sessionPlayerId = messagingService.getPlayerIdForSession(session.id)
@@ -42,14 +42,20 @@ class PlayCardHandler(
                 isRotated = command.isRotated
             )
 
-            messagingService.sendEventToLobby(lobbyCode, GameEvent.GameStateUpdate(result.updatedGameState))
+            messagingService.sendEventToLobby(
+                lobbyCode,
+                GameEvent.GameStateUpdate(result.updatedGameState)
+            )
             messagingService.sendEventToLobby(lobbyCode, GameEvent.CardsDealt(result.updatedHands))
-            
+
             if (result.winner != null) {
                 messagingService.sendEventToLobby(lobbyCode, GameEvent.GameOver(result.winner))
-                // Clean up lobby after game over so players aren't "pulled back" into a finished game
-                lobbyService.deleteLobbyInternal(lobbyCode, "game_over")
+                if (result.updatedGameState.isGameOver) {
+                    lobbyService.deleteLobbyInternal(lobbyCode, "game_over")
+                }
             }
         }
     }
 }
+
+

--- a/server/src/main/kotlin/com/aau/server/websocket/command/handlers/PlayCardHandler.kt
+++ b/server/src/main/kotlin/com/aau/server/websocket/command/handlers/PlayCardHandler.kt
@@ -51,7 +51,7 @@ class PlayCardHandler(
             if (result.winner != null) {
                 messagingService.sendEventToLobby(lobbyCode, GameEvent.GameOver(result.winner))
                 if (result.updatedGameState.isGameOver) {
-                    lobbyService.deleteLobbyInternal(lobbyCode, "game_over")
+                    lobbyService.resetAfterGame(lobbyCode)
                 }
             }
         }

--- a/server/src/test/kotlin/com/aau/server/service/LobbyServiceTest.kt
+++ b/server/src/test/kotlin/com/aau/server/service/LobbyServiceTest.kt
@@ -152,4 +152,26 @@ class LobbyServiceTest {
         // Verified by side effect in cleanup logic or internal state check if visible
         assertNotNull(lobby.lobbyCode)
     }
+
+    @Test
+    fun `resetAfterGame resets gameStarted to false and cleans game data`() {
+        val lobby = lobbyService.createLobby("Host", "h1")
+        lobbyService.markGameStarted(lobby.lobbyCode)
+
+        lobbyService.resetAfterGame(lobby.lobbyCode)
+
+        val reset = lobbyService.getLobby(lobby.lobbyCode)
+        assertFalse(reset.gameStarted)
+        verify(turnManager).removeGame(lobby.lobbyCode)
+        verify(gameService).removePlayerData(lobby.lobbyCode)
+        verify(lobbyRepository, atLeast(2)).save(any())
+    }
+
+    @Test
+    fun `resetAfterGame does nothing when lobby not found`() {
+        lobbyService.resetAfterGame("nonexistent")
+
+        verify(turnManager, never()).removeGame(any())
+        verify(gameService, never()).removePlayerData(any())
+    }
 }

--- a/server/src/test/kotlin/com/aau/server/websocket/command/handlers/DiscardCardHandlerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/websocket/command/handlers/DiscardCardHandlerTest.kt
@@ -64,7 +64,7 @@ class DiscardCardHandlerTest {
         handler.handle(session, command)
 
         verify(messagingService, times(3)).sendEventToLobby(eq(lobbyCode), any())
-        verify(lobbyService).deleteLobbyInternal(lobbyCode, "game_over")
+        verify(lobbyService).resetAfterGame(lobbyCode)
     }
 
     @Test
@@ -86,7 +86,7 @@ class DiscardCardHandlerTest {
         handler.handle(session, command)
 
         verify(messagingService, times(3)).sendEventToLobby(eq(lobbyCode), any())
-        verify(lobbyService, never()).deleteLobbyInternal(lobbyCode, "game_over")
+        verify(lobbyService, never()).resetAfterGame(lobbyCode)
     }
 
     @Test

--- a/server/src/test/kotlin/com/aau/server/websocket/command/handlers/DiscardCardHandlerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/websocket/command/handlers/DiscardCardHandlerTest.kt
@@ -46,11 +46,15 @@ class DiscardCardHandlerTest {
     }
 
     @Test
-    fun `handle discard card with winner cleans up lobby`() {
+    fun `handle discard card with winner cleans up lobby when game over`() {
         val lobbyCode = "1234"
         val playerId = "player-1"
         val command = DiscardCardCommand(playerId, "card-1")
-        val turnResult = TurnResult(GameState(emptyList(), "next-player"), emptyMap(), "SABOTEURS")
+        val turnResult = TurnResult(
+            GameState(emptyList(), "next-player", isGameOver = true),
+            emptyMap(),
+            "SABOTEURS"
+        )
 
         whenever(messagingService.getLobbyCodeForSession("session-1")).thenReturn(lobbyCode)
         whenever(messagingService.getLobbyLock(lobbyCode)).thenReturn(ReentrantLock())
@@ -61,6 +65,28 @@ class DiscardCardHandlerTest {
 
         verify(messagingService, times(3)).sendEventToLobby(eq(lobbyCode), any())
         verify(lobbyService).deleteLobbyInternal(lobbyCode, "game_over")
+    }
+
+    @Test
+    fun `handle discard card with winner in middle round does not clean up lobby`() {
+        val lobbyCode = "1234"
+        val playerId = "player-1"
+        val command = DiscardCardCommand(playerId, "card-1")
+        val turnResult = TurnResult(
+            GameState(emptyList(), "next-player", isGameOver = false),
+            emptyMap(),
+            "SABOTEURS"
+        )
+
+        whenever(messagingService.getLobbyCodeForSession("session-1")).thenReturn(lobbyCode)
+        whenever(messagingService.getLobbyLock(lobbyCode)).thenReturn(ReentrantLock())
+        whenever(messagingService.getPlayerIdForSession("session-1")).thenReturn(playerId)
+        whenever(turnManager.discardCard(lobbyCode, playerId, "card-1")).thenReturn(turnResult)
+
+        handler.handle(session, command)
+
+        verify(messagingService, times(3)).sendEventToLobby(eq(lobbyCode), any())
+        verify(lobbyService, never()).deleteLobbyInternal(lobbyCode, "game_over")
     }
 
     @Test

--- a/server/src/test/kotlin/com/aau/server/websocket/command/handlers/PlayCardHandlerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/websocket/command/handlers/PlayCardHandlerTest.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.locks.ReentrantLock
 
 class PlayCardHandlerTest {
 
-    // Gemeinsame Mocks
+
     private val messagingService: MessagingService = mock()
     private val turnManager: TurnManager = mock()
     private val lobbyService: LobbyService = mock()
@@ -51,11 +51,15 @@ class PlayCardHandlerTest {
     }
 
     @Test
-    fun `handle play card with winner cleans up lobby`() {
+    fun `handle play card with winner cleans up lobby when game over`() {
         val lobbyCode = "1234"
         val playerId = "player-1"
         val command = PlayCardCommand(playerId, "card-1", BoardPosition(0, 0), false)
-        val turnResult = TurnResult(GameState(emptyList(), "next-player"), emptyMap(), "DWARVES")
+        val turnResult = TurnResult(
+            GameState(emptyList(), "next-player", isGameOver = true),
+            emptyMap(),
+            "DWARVES"
+        )
 
         whenever(messagingService.getLobbyCodeForSession("session-1")).thenReturn(lobbyCode)
         whenever(messagingService.getLobbyLock(lobbyCode)).thenReturn(ReentrantLock())
@@ -66,6 +70,28 @@ class PlayCardHandlerTest {
 
         verify(messagingService, times(3)).sendEventToLobby(eq(lobbyCode), any())
         verify(lobbyService).deleteLobbyInternal(eq(lobbyCode), any())
+    }
+
+    @Test
+    fun `handle play card with winner in middle round does not clean up lobby`() {
+        val lobbyCode = "1234"
+        val playerId = "player-1"
+        val command = PlayCardCommand(playerId, "card-1", BoardPosition(0, 0), false)
+        val turnResult = TurnResult(
+            GameState(emptyList(), "next-player", isGameOver = false),
+            emptyMap(),
+            "DWARVES"
+        )
+
+        whenever(messagingService.getLobbyCodeForSession("session-1")).thenReturn(lobbyCode)
+        whenever(messagingService.getLobbyLock(lobbyCode)).thenReturn(ReentrantLock())
+        whenever(messagingService.getPlayerIdForSession("session-1")).thenReturn(playerId)
+        whenever(turnManager.playCard(eq(lobbyCode), eq(playerId), eq("card-1"), any(), eq(false))).thenReturn(turnResult)
+
+        playCardHandler.handle(session, command)
+
+        verify(messagingService, times(3)).sendEventToLobby(eq(lobbyCode), any())
+        verify(lobbyService, never()).deleteLobbyInternal(eq(lobbyCode), any())
     }
 
     @Test

--- a/server/src/test/kotlin/com/aau/server/websocket/command/handlers/PlayCardHandlerTest.kt
+++ b/server/src/test/kotlin/com/aau/server/websocket/command/handlers/PlayCardHandlerTest.kt
@@ -69,7 +69,7 @@ class PlayCardHandlerTest {
         playCardHandler.handle(session, command)
 
         verify(messagingService, times(3)).sendEventToLobby(eq(lobbyCode), any())
-        verify(lobbyService).deleteLobbyInternal(eq(lobbyCode), any())
+        verify(lobbyService).resetAfterGame(eq(lobbyCode))
     }
 
     @Test
@@ -91,7 +91,7 @@ class PlayCardHandlerTest {
         playCardHandler.handle(session, command)
 
         verify(messagingService, times(3)).sendEventToLobby(eq(lobbyCode), any())
-        verify(lobbyService, never()).deleteLobbyInternal(eq(lobbyCode), any())
+        verify(lobbyService, never()).resetAfterGame(eq(lobbyCode))
     }
 
     @Test

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.coverage.jacoco.xmlReportPaths=app/app/build/reports/jacoco/jacocoTestDebu
 # 4. GLOBAL EXCLUSIONS
 # Exclude server, shared modules, and UI components from the app analysis
 sonar.exclusions=server/**,shared/**,app/app/build/**,app/app/src/main/java/com/aau/saboteur/ui/**
-sonar.coverage.exclusions=server/**,shared/**,app/app/build/**,app/app/src/main/java/com/aau/saboteur/ui/**
+sonar.coverage.exclusions=server/**,shared/**,app/app/build/**,app/app/src/main/java/com/aau/saboteur/ui/**,app/app/src/main/java/com/aau/saboteur/navigation/**
 
 # 5. Encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Zusammenfassung

Implementierung und Bugfixes für die Result-Screens sowie die Zurück-zur-Lobby-Flow.

## Gelöste Issues

### #104: Gesperrte Spieler Anzeige überarbeiten
- Blockierte Tools werden jetzt mit **roten Rändern** statt nur Emoji angezeigt
- Icons erscheinen nur wenn ein Spieler tatsächlich gesperrt ist
- Verbesserte visuelle Konsistenz mit dem Kartendesign
- **Geänderte Dateien:**
  - `PlayerCard.kt`: Icon-Container mit Rand hinzugefügt
  - `GameScreen.kt`: `ToolIcons()` Composable aktualisiert

### #107: Rundenende-Screen implementiert
- **RoundResultScreen.kt**: Zeigt Rundenzusammenfassung mit:
  - Aufgedeckte Rollen aller Spieler
  - Punkte der Runde für jeden Spieler
  - Gesamtpunktestand
  - "Nächste Runde"-Button zum Fortfahren
- **FinalResultScreen.kt**: Zeigt Endergebnis mit:
  - Finale Punktestände und Gesamtgewinner
  - Einzelner "Zurück zur Lobby"-Button

## Bugfixes

### Double-Trigger behoben
- `observeRoundResults()` aus `GameViewModel` entfernt — Result-Screens werden nur noch über `observeGameOverEvents()` getriggert

### Lobby-Deletion nach jeder Runde behoben
- `PlayCardHandler` und `DiscardCardHandler` löschten die Lobby nach **jeder** Rundenende (weil `winner != null` nach jeder Runde)
- Fix: `deleteLobbyInternal()` → `resetAfterGame()`, nur wenn `isGameOver = true`
- Server setzt Lobby auf `gameStarted = false` statt sie zu löschen — alle Spieler landen automatisch wieder in der aktiven Lobby

## Verwandte Änderungen
- Result-Screens in `GameScreen.kt` Event-Handler integriert
- `AppNavHost.kt`: `onBackToActiveLobby`-Navigation nach Spielende verdrahtet
- `LobbyService.kt`: `resetAfterGame()` hinzugefügt
- Tests in `PlayCardHandlerTest` und `DiscardCardHandlerTest` aktualisiert