### PR TITLE
feat: finalize cheat rules documentation

### DIFF
--- a/app/app/src/main/java/com/aau/saboteur/ui/components/SpielregelnDialog.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/SpielregelnDialog.kt
@@ -99,15 +99,17 @@ fun SpielregelnDialog(onDismiss: () -> Unit) {
                                     }
                                 },
                                 update = { webView ->
-                                    val html = """
-                                        <html>
-                                        <body style="margin:0; padding:0; background-color:#1A1A1A;">
-                                            <img src="file:///android_asset/${imagePages[currentPage]}" style="width:100%;" />
-                                            <div style="height: 180px;"></div>
-                                        </body>
-                                        </html>
-                                    """.trimIndent()
-                                    webView.loadDataWithBaseURL("file:///android_asset/", html, "text/html", "UTF-8", null)
+                                    if (currentPage < imagePages.size) {
+                                        val html = """
+                                            <html>
+                                            <body style="margin:0; padding:0; background-color:#1A1A1A;">
+                                                <img src="file:///android_asset/${imagePages[currentPage]}" style="width:100%;" />
+                                                <div style="height: 180px;"></div>
+                                            </body>
+                                            </html>
+                                        """.trimIndent()
+                                        webView.loadDataWithBaseURL("file:///android_asset/", html, "text/html", "UTF-8", null)
+                                    }
                                 }
                             )
                         } else {

--- a/app/app/src/main/java/com/aau/saboteur/ui/components/SpielregelnDialog.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/components/SpielregelnDialog.kt
@@ -216,6 +216,13 @@ private fun CheatRulesPage(modifier: Modifier = Modifier) {
             title = stringResource(R.string.cheat_lantern_title),
             description = stringResource(R.string.cheat_lantern_desc)
         )
+        Spacer(modifier = Modifier.height(20.dp))
+
+        // 2. NEU: Volume Button Cheat
+        CheatSection(
+            title = stringResource(R.string.cheat_volume_title),
+            description = stringResource(R.string.cheat_volume_desc)
+        )
 
         Spacer(modifier = Modifier.height(20.dp))
 

--- a/app/app/src/main/res/values-de/strings.xml
+++ b/app/app/src/main/res/values-de/strings.xml
@@ -93,7 +93,9 @@
     <!-- Cheats -->
     <string name="cheat_rules_title">Schummelfunktionen</string>
     <string name="cheat_lantern_title">Die magische Taschenlampe</string>
-    <string name="cheat_lantern_desc">Echte Zwerge brauchen Licht! Wenn du eine kaputte Lampe hast (Blockierung), kannst du deine echte Handy-Taschenlampe kurz ein- und ausschalten. Dadurch wird deine Blockierung sofort aufgehoben, ohne dass du eine Reparaturkarte ausspielen musst.</string>
+    <string name="cheat_lantern_desc">Echte Zwerge brauchen Licht! Wenn du eine kaputte Lampe hast (Blockierung), kannst du deine echte Handy-Taschenlampe kurz ein- und ausschalten. Dadurch wird deine Blockierung sofort aufgehoben, ohne dass du eine Reparaturkarte ausspielen musst. Dieser Cheat verbraucht keinen Spielzug!</string>
+    <string name="cheat_volume_title">Die Macht der Lautstärke</string>
+    <string name="cheat_volume_desc">Manchmal passt eine Karte einfach nicht in den Plan. Drücke die Lautstärketasten in der Reihenfolge LAUTER, LAUTER, LEISER, LEISER (innerhalb von 2 Sekunden), um eine zufällige Karte aus deiner Hand abzuwerfen und sofort eine neue zu ziehen. Dieser Cheat verbraucht keinen Spielzug!</string>
     <string name="cheat_risk_title">Risiko &amp; Belohnung</string>
     <string name="cheat_risk_desc">Schummeln ist gefährlich! Nutze diesen Vorteil klug, um dich als Goldgräber zu retten oder als Saboteur unbemerkt voranzukommen. Achte darauf, dass niemand sieht, wie du den Sensor triggerst!</string>
 

--- a/app/app/src/main/res/values-en/strings.xml
+++ b/app/app/src/main/res/values-en/strings.xml
@@ -93,7 +93,9 @@
     <!-- Cheats -->
     <string name="cheat_rules_title">Cheat Functions</string>
     <string name="cheat_lantern_title">The Magic Flashlight</string>
-    <string name="cheat_lantern_desc">True dwarves need light! If you have a broken lantern (blocked), you can briefly turn your real phone flashlight on and off. This will immediately remove your blockage without having to play a repair card.</string>
+    <string name="cheat_lantern_desc">True dwarves need light! If you have a broken lantern (blocked), you can briefly turn your real phone flashlight on and off. This will immediately remove your blockage without having to play a repair card. This cheat does not consume a turn!</string>
+    <string name="cheat_volume_title">Volume Master</string>
+    <string name="cheat_volume_desc">Sometimes a card just doesn\'t fit your strategy. Press the volume keys in the sequence UP, UP, DOWN, DOWN (within 2 seconds) to discard a random card from your hand and immediately draw a new one. This cheat does not consume a turn!</string>
     <string name="cheat_risk_title">Risk &amp; Reward</string>
     <string name="cheat_risk_desc">Cheating is dangerous! Use this advantage wisely to save yourself as a gold digger or to advance unnoticed as a saboteur. Make sure no one sees you triggering the sensor!</string>
 

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -85,17 +85,19 @@
     <string name="error_lobby_leave_unauthorized">Nicht autorisiert: Nur du selbst kannst deine Lobby verlassen.</string>
 
     <!-- Spielregeln -->
-    <string name="spielregeln_button">Game Rules</string>
-    <string name="spielregeln_titel">Game Rules</string>
-    <string name="seite_x_von_y">Page %1$d / %2$d</string>
-    <string name="schliessen">Close</string>
+    <string name="spielregeln_button">Spielregeln</string>
+    <string name="spielregeln_titel">Spielregeln</string>
+    <string name="seite_x_von_y">Seite %1$d / %2$d</string>
+    <string name="schliessen">Schließen</string>
 
     <!-- Cheats -->
-    <string name="cheat_rules_title">Cheat Functions</string>
-    <string name="cheat_lantern_title">The Magic Flashlight</string>
-    <string name="cheat_lantern_desc">True dwarves need light! If you have a broken lantern (blocked), you can briefly turn your real phone flashlight on and off. This will immediately remove your blockage without having to play a repair card.</string>
-    <string name="cheat_risk_title">Risk &amp; Reward</string>
-    <string name="cheat_risk_desc">Cheating is dangerous! Use this advantage wisely to save yourself as a gold digger or to advance unnoticed as a saboteur. Make sure no one sees you triggering the sensor!</string>
+    <string name="cheat_rules_title">Schummelfunktionen</string>
+    <string name="cheat_lantern_title">Die magische Taschenlampe</string>
+    <string name="cheat_lantern_desc">Echte Zwerge brauchen Licht! Wenn du eine kaputte Lampe hast (Blockierung), kannst du deine echte Handy-Taschenlampe kurz ein- und ausschalten. Dadurch wird deine Blockierung sofort aufgehoben, ohne dass du eine Reparaturkarte ausspielen musst. Dieser Cheat verbraucht keinen Spielzug!</string>
+    <string name="cheat_volume_title">Die Macht der Lautstärke</string>
+    <string name="cheat_volume_desc">Manchmal passt eine Karte einfach nicht in den Plan. Drücke die Lautstärketasten in der Reihenfolge LAUTER, LAUTER, LEISER, LEISER (innerhalb von 2 Sekunden), um eine zufällige Karte aus deiner Hand abzuwerfen und sofort eine neue zu ziehen. Dieser Cheat verbraucht keinen Spielzug!</string>
+    <string name="cheat_risk_title">Risiko &amp; Belohnung</string>
+    <string name="cheat_risk_desc">Schummeln ist gefährlich! Nutze diesen Vorteil klug, um dich als Goldgräber zu retten oder als Saboteur unbemerkt voranzukommen. Achte darauf, dass niemand sieht, wie du den Sensor triggerst!</string>
 
     <!-- Menu actions -->
     <string name="menu_toggle">Menü öffnen/schließen</string>


### PR DESCRIPTION
 Feature: Cheat-Regeln (#159)
Dokumentation für den Volume Button Discard Cheat hinzugefügt.

Anleitungen in Deutsch und Englisch ergänzt.

Klarstellung hinzugefügt, dass weder der Taschenlampen-Cheat noch der Volume-Cheat einen Spielzug verbrauchen.