### PR TITLE
refactor: enable i18n for end-of-round and final result screens

### DIFF
--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/FinalResultScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/FinalResultScreen.kt
@@ -11,15 +11,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.aau.saboteur.R
 import com.aau.saboteur.model.PlayerTurn
 import com.aau.saboteur.model.Role
 import com.aau.saboteur.model.RoundResult
 import com.aau.saboteur.ui.theme.OreGold
+import com.aau.saboteur.util.LanguageManager
+import com.aau.saboteur.util.rememberLocalizedContext
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 
 @Composable
 fun FinalResultScreen(
@@ -27,271 +34,280 @@ fun FinalResultScreen(
     players: List<PlayerTurn>,
     onBackToLobby: () -> Unit
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
-        contentAlignment = Alignment.Center
-    ) {
-        Column(
+    val language by LanguageManager.currentLanguage
+    val localizedContext = rememberLocalizedContext(language)
+
+    CompositionLocalProvider(LocalContext provides localizedContext) {
+        Box(
             modifier = Modifier
-                .fillMaxWidth(0.9f)
-                .wrapContentHeight(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+            contentAlignment = Alignment.Center
         ) {
-            Card(
-                modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(16.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface
-                ),
-                border = BorderStroke(2.dp, OreGold),
-                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth(0.9f)
+                    .wrapContentHeight(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(24.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surface
+                    ),
+                    border = BorderStroke(2.dp, OreGold),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
                 ) {
-                    Text(
-                        text = "🏆 Spiel beendet",
-                        style = MaterialTheme.typography.headlineMedium.copy(
-                            fontSize = 28.sp,
-                            fontWeight = FontWeight.ExtraBold,
-                            fontFamily = FontFamily.SansSerif
-                        ),
-                        color = MaterialTheme.colorScheme.onSurface,
-                        textAlign = TextAlign.Center
-                    )
-
-                    val winnerColor = if (roundResult.winnerRole == Role.GOLDDIGGER)
-                        OreGold else Color(0xFFD32F2F)
-                    val winnerIcon = if (roundResult.winnerRole == Role.GOLDDIGGER) "⛏️" else "🔴"
-                    val winnerText = if (roundResult.winnerRole == Role.GOLDDIGGER)
-                        "Goldsucher gewinnen" else "Saboteure gewinnen"
-
-                    Surface(
-                        modifier = Modifier.fillMaxWidth(),
-                        shape = RoundedCornerShape(12.dp),
-                        color = winnerColor.copy(alpha = 0.2f),
-                        border = BorderStroke(1.dp, winnerColor)
-                    ) {
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(12.dp),
-                            horizontalArrangement = Arrangement.Center,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(winnerIcon, fontSize = 20.sp)
-                            Spacer(Modifier.width(8.dp))
-                            Text(
-                                text = winnerText,
-                                style = MaterialTheme.typography.titleMedium.copy(
-                                    fontWeight = FontWeight.Bold,
-                                    fontFamily = FontFamily.SansSerif
-                                ),
-                                color = winnerColor
-                            )
-                        }
-                    }
-
-                    Text(
-                        text = "Rollen der letzten Runde",
-                        style = MaterialTheme.typography.labelMedium.copy(
-                            fontWeight = FontWeight.Bold,
-                            fontFamily = FontFamily.SansSerif
-                        ),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Start
-                    )
-
-                    LazyColumn(
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .heightIn(max = 120.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                            .padding(24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        items(players) { player ->
-                            val revealedRole = roundResult.revealedRoles[player.playerId]
-                            val roleIcon = when (revealedRole) {
-                                Role.GOLDDIGGER -> "⛏️"
-                                Role.SABOTEUR -> "🔴"
-                                null -> "❓"
-                            }
-                            val roleText = when (revealedRole) {
-                                Role.GOLDDIGGER -> "Goldsucher"
-                                Role.SABOTEUR -> "Saboteur"
-                                null -> "Unbekannt"
-                            }
-                            val roleColor = when (revealedRole) {
-                                Role.GOLDDIGGER -> OreGold
-                                Role.SABOTEUR -> Color(0xFFD32F2F)
-                                null -> Color.Gray
-                            }
+                        Text(
+                            text = stringResource(R.string.final_result_title),
+                            style = MaterialTheme.typography.headlineMedium.copy(
+                                fontSize = 28.sp,
+                                fontWeight = FontWeight.ExtraBold,
+                                fontFamily = FontFamily.SansSerif
+                            ),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            textAlign = TextAlign.Center
+                        )
 
-                            Surface(
-                                modifier = Modifier.fillMaxWidth(),
-                                shape = RoundedCornerShape(8.dp),
-                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                        val winnerColor = if (roundResult.winnerRole == Role.GOLDDIGGER)
+                            OreGold else Color(0xFFD32F2F)
+                        val winnerIcon = if (roundResult.winnerRole == Role.GOLDDIGGER) "⛏️" else "🔴"
+                        val winnerText = if (roundResult.winnerRole == Role.GOLDDIGGER)
+                            stringResource(R.string.round_result_winner_golddiggers) else stringResource(R.string.round_result_winner_saboteurs)
+
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(12.dp),
+                            color = winnerColor.copy(alpha = 0.2f),
+                            border = BorderStroke(1.dp, winnerColor)
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(12.dp),
+                                horizontalArrangement = Arrangement.Center,
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Row(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(10.dp),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                    verticalAlignment = Alignment.CenterVertically
+                                Text(winnerIcon, fontSize = 20.sp)
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    text = winnerText,
+                                    style = MaterialTheme.typography.titleMedium.copy(
+                                        fontWeight = FontWeight.Bold,
+                                        fontFamily = FontFamily.SansSerif
+                                    ),
+                                    color = winnerColor
+                                )
+                            }
+                        }
+
+                        Text(
+                            text = stringResource(R.string.final_result_roles_title),
+                            style = MaterialTheme.typography.labelMedium.copy(
+                                fontWeight = FontWeight.Bold,
+                                fontFamily = FontFamily.SansSerif
+                            ),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.fillMaxWidth(),
+                            textAlign = TextAlign.Start
+                        )
+
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(max = 120.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            items(players) { player ->
+                                val revealedRole = roundResult.revealedRoles[player.playerId]
+                                val roleIcon = when (revealedRole) {
+                                    Role.GOLDDIGGER -> "⛏️"
+                                    Role.SABOTEUR -> "🔴"
+                                    null -> "❓"
+                                }
+                                val roleText = when (revealedRole) {
+                                    Role.GOLDDIGGER -> stringResource(R.string.role_golddigger_label)
+                                    Role.SABOTEUR -> stringResource(R.string.role_saboteur_label)
+                                    null -> stringResource(R.string.role_unknown_label)
+                                }
+                                val roleColor = when (revealedRole) {
+                                    Role.GOLDDIGGER -> OreGold
+                                    Role.SABOTEUR -> Color(0xFFD32F2F)
+                                    null -> Color.Gray
+                                }
+
+                                Surface(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    shape = RoundedCornerShape(8.dp),
+                                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
                                 ) {
                                     Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(6.dp)
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(10.dp),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically
                                     ) {
-                                        Text(roleIcon, fontSize = 16.sp)
+                                        Row(
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            horizontalArrangement = Arrangement.spacedBy(6.dp)
+                                        ) {
+                                            Text(roleIcon, fontSize = 16.sp)
+                                            Text(
+                                                text = player.playerName,
+                                                style = MaterialTheme.typography.bodySmall.copy(
+                                                    fontFamily = FontFamily.SansSerif
+                                                ),
+                                                color = MaterialTheme.colorScheme.onSurface
+                                            )
+                                        }
                                         Text(
-                                            text = player.playerName,
+                                            text = roleText,
+                                            style = MaterialTheme.typography.bodySmall.copy(
+                                                fontWeight = FontWeight.Bold,
+                                                fontFamily = FontFamily.SansSerif
+                                            ),
+                                            color = roleColor
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
+                        HorizontalDivider(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp),
+                            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
+                        )
+
+                        Text(
+                            text = stringResource(R.string.final_result_gold_title),
+                            style = MaterialTheme.typography.labelMedium.copy(
+                                fontWeight = FontWeight.Bold,
+                                fontFamily = FontFamily.SansSerif
+                            ),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.fillMaxWidth(),
+                            textAlign = TextAlign.Start
+                        )
+
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(max = 100.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            items(
+                                roundResult.playerGoldTotals.entries.sortedByDescending { it.value }
+                            ) { (playerId, gold) ->
+                                val playerName = players.find { it.playerId == playerId }?.playerName ?: stringResource(R.string.role_unknown_label)
+
+                                Surface(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    shape = RoundedCornerShape(8.dp),
+                                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                                ) {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(10.dp),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Text(
+                                            text = playerName,
                                             style = MaterialTheme.typography.bodySmall.copy(
                                                 fontFamily = FontFamily.SansSerif
                                             ),
                                             color = MaterialTheme.colorScheme.onSurface
                                         )
-                                    }
-                                    Text(
-                                        text = roleText,
-                                        style = MaterialTheme.typography.bodySmall.copy(
-                                            fontWeight = FontWeight.Bold,
-                                            fontFamily = FontFamily.SansSerif
-                                        ),
-                                        color = roleColor
-                                    )
-                                }
-                            }
-                        }
-                    }
-
-                    HorizontalDivider(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(vertical = 8.dp),
-                        color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
-                    )
-
-                    Text(
-                        text = "Endgültiger Goldstand",
-                        style = MaterialTheme.typography.labelMedium.copy(
-                            fontWeight = FontWeight.Bold,
-                            fontFamily = FontFamily.SansSerif
-                        ),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Start
-                    )
-
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(max = 100.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp)
-                    ) {
-                        items(
-                            roundResult.playerGoldTotals.entries.sortedByDescending { it.value }
-                        ) { (playerId, gold) ->
-                            val playerName = players.find { it.playerId == playerId }?.playerName ?: "Unknown"
-
-                            Surface(
-                                modifier = Modifier.fillMaxWidth(),
-                                shape = RoundedCornerShape(8.dp),
-                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-                            ) {
-                                Row(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(10.dp),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Text(
-                                        text = playerName,
-                                        style = MaterialTheme.typography.bodySmall.copy(
-                                            fontFamily = FontFamily.SansSerif
-                                        ),
-                                        color = MaterialTheme.colorScheme.onSurface
-                                    )
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(4.dp)
-                                    ) {
-                                        Text(
-                                            text = gold.toString(),
-                                            style = MaterialTheme.typography.bodySmall.copy(
-                                                fontWeight = FontWeight.Bold,
-                                                fontFamily = FontFamily.SansSerif
-                                            ),
-                                            color = OreGold
-                                        )
-                                        Text("🪙", fontSize = 14.sp)
+                                        Row(
+                                            verticalAlignment = Alignment.CenterVertically,
+                                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                                        ) {
+                                            Text(
+                                                text = gold.toString(),
+                                                style = MaterialTheme.typography.bodySmall.copy(
+                                                    fontWeight = FontWeight.Bold,
+                                                    fontFamily = FontFamily.SansSerif
+                                                ),
+                                                color = OreGold
+                                            )
+                                            Text("🪙", fontSize = 14.sp)
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
 
-                    Surface(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 8.dp),
-                        shape = RoundedCornerShape(12.dp),
-                        color = OreGold.copy(alpha = 0.15f),
-                        border = BorderStroke(1.dp, OreGold.copy(alpha = 0.5f))
-                    ) {
-                        val winnerPlayer = players.find { player ->
-                            roundResult.playerGoldTotals[player.playerId] ==
-                                    roundResult.playerGoldTotals.values.maxOrNull()
-                        }
-                        val winnerGold = roundResult.playerGoldTotals.values.maxOrNull() ?: 0
-
-                        Column(
+                        Surface(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(12.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                                .padding(top = 8.dp),
+                            shape = RoundedCornerShape(12.dp),
+                            color = OreGold.copy(alpha = 0.15f),
+                            border = BorderStroke(1.dp, OreGold.copy(alpha = 0.5f))
                         ) {
-                            Text(
-                                text = "🏆 ${winnerPlayer?.playerName ?: "Unknown"} gewinnt mit $winnerGold Goldstücken",
-                                style = MaterialTheme.typography.bodyMedium.copy(
-                                    fontWeight = FontWeight.ExtraBold,
-                                    fontFamily = FontFamily.SansSerif
-                                ),
-                                color = OreGold,
-                                textAlign = TextAlign.Center
-                            )
+                            val winnerPlayer = players.find { player ->
+                                roundResult.playerGoldTotals[player.playerId] ==
+                                        roundResult.playerGoldTotals.values.maxOrNull()
+                            }
+                            val winnerGold = roundResult.playerGoldTotals.values.maxOrNull() ?: 0
+
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(12.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(4.dp)
+                            ) {
+                                Text(
+                                    text = stringResource(
+                                        R.string.final_result_winner_msg,
+                                        winnerPlayer?.playerName ?: stringResource(R.string.role_unknown_label),
+                                        winnerGold
+                                    ),
+                                    style = MaterialTheme.typography.bodyMedium.copy(
+                                        fontWeight = FontWeight.ExtraBold,
+                                        fontFamily = FontFamily.SansSerif
+                                    ),
+                                    color = OreGold,
+                                    textAlign = TextAlign.Center
+                                )
+                            }
                         }
                     }
                 }
-            }
 
-            Button(
-                onClick = onBackToLobby,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(48.dp),
-                shape = RoundedCornerShape(8.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary
-                )
-            ) {
-                Text(
-                    "Zurück zur Lobby",
-                    style = MaterialTheme.typography.titleSmall.copy(
-                        fontWeight = FontWeight.ExtraBold,
-                        fontFamily = FontFamily.SansSerif
+                Button(
+                    onClick = onBackToLobby,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    shape = RoundedCornerShape(8.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary
                     )
-                )
+                ) {
+                    Text(
+                        text = stringResource(R.string.back_to_lobby_button),
+                        style = MaterialTheme.typography.titleSmall.copy(
+                            fontWeight = FontWeight.ExtraBold,
+                            fontFamily = FontFamily.SansSerif
+                        )
+                    )
+                }
             }
         }
     }

--- a/app/app/src/main/java/com/aau/saboteur/ui/screens/RoundResultScreen.kt
+++ b/app/app/src/main/java/com/aau/saboteur/ui/screens/RoundResultScreen.kt
@@ -9,15 +9,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.aau.saboteur.R
 import com.aau.saboteur.model.PlayerTurn
 import com.aau.saboteur.model.Role
 import com.aau.saboteur.model.RoundResult
 import com.aau.saboteur.ui.theme.OreGold
+import com.aau.saboteur.util.LanguageManager
+import com.aau.saboteur.util.rememberLocalizedContext
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 
 @Composable
 fun RoundResultScreen(
@@ -25,165 +32,170 @@ fun RoundResultScreen(
     players: List<PlayerTurn>,
     onNextRound: () -> Unit
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
-        contentAlignment = Alignment.Center
-    ) {
-        Card(
+    val language by LanguageManager.currentLanguage
+    val localizedContext = rememberLocalizedContext(language)
+
+    CompositionLocalProvider(LocalContext provides localizedContext) {
+        Box(
             modifier = Modifier
-                .fillMaxWidth(0.9f)
-                .wrapContentHeight(),
-            shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface
-            ),
-            border = BorderStroke(2.dp, OreGold),
-            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+            contentAlignment = Alignment.Center
         ) {
-            Column(
+            Card(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(24.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                    .fillMaxWidth(0.9f)
+                    .wrapContentHeight(),
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                ),
+                border = BorderStroke(2.dp, OreGold),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
             ) {
-
-                Text(
-                    text = "Runde ${roundResult.roundNumber} beendet",
-                    style = MaterialTheme.typography.headlineMedium.copy(
-                        fontSize = 28.sp,
-                        fontWeight = FontWeight.ExtraBold,
-                        fontFamily = FontFamily.SansSerif
-                    ),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    textAlign = TextAlign.Center,
-                    maxLines = 1
-                )
-
-
-                val winnerColor = if (roundResult.winnerRole == Role.GOLDDIGGER)
-                    OreGold else Color(0xFFD32F2F)
-                val winnerIcon = if (roundResult.winnerRole == Role.GOLDDIGGER) "⛏️" else "🔴"
-                val winnerText = if (roundResult.winnerRole == Role.GOLDDIGGER)
-                    "Goldsucher gewinnen" else "Saboteure gewinnen"
-
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(12.dp),
-                    color = winnerColor.copy(alpha = 0.2f),
-                    border = BorderStroke(1.dp, winnerColor)
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(12.dp),
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically
+
+                    Text(
+                        text = stringResource(R.string.round_result_title, roundResult.roundNumber),
+                        style = MaterialTheme.typography.headlineMedium.copy(
+                            fontSize = 28.sp,
+                            fontWeight = FontWeight.ExtraBold,
+                            fontFamily = FontFamily.SansSerif
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center,
+                        maxLines = 1
+                    )
+
+
+                    val winnerColor = if (roundResult.winnerRole == Role.GOLDDIGGER)
+                        OreGold else Color(0xFFD32F2F)
+                    val winnerIcon = if (roundResult.winnerRole == Role.GOLDDIGGER) "⛏️" else "🔴"
+                    val winnerText = if (roundResult.winnerRole == Role.GOLDDIGGER)
+                        stringResource(R.string.round_result_winner_golddiggers) else stringResource(R.string.round_result_winner_saboteurs)
+
+                    Surface(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(12.dp),
+                        color = winnerColor.copy(alpha = 0.2f),
+                        border = BorderStroke(1.dp, winnerColor)
                     ) {
-                        Text(winnerIcon, fontSize = 20.sp)
-                        Spacer(Modifier.width(8.dp))
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(12.dp),
+                            horizontalArrangement = Arrangement.Center,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(winnerIcon, fontSize = 20.sp)
+                            Spacer(Modifier.width(8.dp))
+                            Text(
+                                text = winnerText,
+                                style = MaterialTheme.typography.titleMedium.copy(
+                                    fontWeight = FontWeight.Bold,
+                                    fontFamily = FontFamily.SansSerif
+                                ),
+                                color = winnerColor
+                            )
+                        }
+                    }
+
+
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
                         Text(
-                            text = winnerText,
-                            style = MaterialTheme.typography.titleMedium.copy(
+                            text = stringResource(R.string.round_result_roles_title),
+                            style = MaterialTheme.typography.labelMedium.copy(
                                 fontWeight = FontWeight.Bold,
                                 fontFamily = FontFamily.SansSerif
                             ),
-                            color = winnerColor
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
-                    }
-                }
 
+                        players.forEach { player ->
+                            val revealedRole = roundResult.revealedRoles[player.playerId]
+                            val roleIcon = when (revealedRole) {
+                                Role.GOLDDIGGER -> "⛏️"
+                                Role.SABOTEUR -> "🔴"
+                                null -> "❓"
+                            }
+                            val roleText = when (revealedRole) {
+                                Role.GOLDDIGGER -> stringResource(R.string.role_golddigger_label)
+                                Role.SABOTEUR -> stringResource(R.string.role_saboteur_label)
+                                null -> stringResource(R.string.role_unknown_label)
+                            }
+                            val roleColor = when (revealedRole) {
+                                Role.GOLDDIGGER -> OreGold
+                                Role.SABOTEUR -> Color(0xFFD32F2F)
+                                null -> Color.Gray
+                            }
 
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Text(
-                        text = "Rollen dieser Runde",
-                        style = MaterialTheme.typography.labelMedium.copy(
-                            fontWeight = FontWeight.Bold,
-                            fontFamily = FontFamily.SansSerif
-                        ),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-
-                    players.forEach { player ->
-                        val revealedRole = roundResult.revealedRoles[player.playerId]
-                        val roleIcon = when (revealedRole) {
-                            Role.GOLDDIGGER -> "⛏️"
-                            Role.SABOTEUR -> "🔴"
-                            null -> "❓"
-                        }
-                        val roleText = when (revealedRole) {
-                            Role.GOLDDIGGER -> "Goldsucher"
-                            Role.SABOTEUR -> "Saboteur"
-                            null -> "Unbekannt"
-                        }
-                        val roleColor = when (revealedRole) {
-                            Role.GOLDDIGGER -> OreGold
-                            Role.SABOTEUR -> Color(0xFFD32F2F)
-                            null -> Color.Gray
-                        }
-
-                        Surface(
-                            modifier = Modifier.fillMaxWidth(),
-                            shape = RoundedCornerShape(8.dp),
-                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
-                        ) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(12.dp),
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                verticalAlignment = Alignment.CenterVertically
+                            Surface(
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = RoundedCornerShape(8.dp),
+                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
                             ) {
                                 Row(
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(12.dp),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Text(roleIcon, fontSize = 18.sp)
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    ) {
+                                        Text(roleIcon, fontSize = 18.sp)
+                                        Text(
+                                            text = player.playerName,
+                                            style = MaterialTheme.typography.bodyMedium.copy(
+                                                fontFamily = FontFamily.SansSerif
+                                            ),
+                                            color = MaterialTheme.colorScheme.onSurface
+                                        )
+                                    }
                                     Text(
-                                        text = player.playerName,
+                                        text = roleText,
                                         style = MaterialTheme.typography.bodyMedium.copy(
+                                            fontWeight = FontWeight.Bold,
                                             fontFamily = FontFamily.SansSerif
                                         ),
-                                        color = MaterialTheme.colorScheme.onSurface
+                                        color = roleColor
                                     )
                                 }
-                                Text(
-                                    text = roleText,
-                                    style = MaterialTheme.typography.bodyMedium.copy(
-                                        fontWeight = FontWeight.Bold,
-                                        fontFamily = FontFamily.SansSerif
-                                    ),
-                                    color = roleColor
-                                )
                             }
                         }
                     }
-                }
 
 
-                Button(
-                    onClick = onNextRound,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(48.dp),
-                    shape = RoundedCornerShape(8.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary
-                    )
-                ) {
-                    Text(
-                        "Weiter zur nächsten Runde",
-                        style = MaterialTheme.typography.titleSmall.copy(
-                            fontWeight = FontWeight.ExtraBold,
-                            fontFamily = FontFamily.SansSerif
+                    Button(
+                        onClick = onNextRound,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(48.dp),
+                        shape = RoundedCornerShape(8.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary,
+                            contentColor = MaterialTheme.colorScheme.onPrimary
                         )
-                    )
+                    ) {
+                        Text(
+                            text = stringResource(R.string.next_round_button_label),
+                            style = MaterialTheme.typography.titleSmall.copy(
+                                fontWeight = FontWeight.ExtraBold,
+                                fontFamily = FontFamily.SansSerif
+                            )
+                        )
+                    }
                 }
             }
         }

--- a/app/app/src/main/res/values-de/strings.xml
+++ b/app/app/src/main/res/values-de/strings.xml
@@ -97,6 +97,22 @@
     <string name="cheat_risk_title">Risiko &amp; Belohnung</string>
     <string name="cheat_risk_desc">Schummeln ist gefährlich! Nutze diesen Vorteil klug, um dich als Goldgräber zu retten oder als Saboteur unbemerkt voranzukommen. Achte darauf, dass niemand sieht, wie du den Sensor triggerst!</string>
 
+    <!-- Round Results -->
+    <string name="round_result_title">Runde %1$d beendet</string>
+    <string name="round_result_winner_golddiggers">Goldsucher gewinnen</string>
+    <string name="round_result_winner_saboteurs">Saboteure gewinnen</string>
+    <string name="round_result_roles_title">Rollen dieser Runde</string>
+    <string name="role_golddigger_label">Goldsucher</string>
+    <string name="role_saboteur_label">Saboteur</string>
+    <string name="role_unknown_label">Unbekannt</string>
+    <string name="next_round_button_label">Weiter zur nächsten Runde</string>
+
+    <!-- Final Results -->
+    <string name="final_result_title">🏆 Spiel beendet</string>
+    <string name="final_result_roles_title">Rollen der letzten Runde</string>
+    <string name="final_result_gold_title">Endgültiger Goldstand</string>
+    <string name="final_result_winner_msg">🏆 %1$s gewinnt mit %2$d Goldstücken</string>
+
     <!-- Menu actions -->
     <string name="menu_toggle">Menü öffnen/schließen</string>
     <string name="leave_game">Spiel verlassen</string>

--- a/app/app/src/main/res/values-en/strings.xml
+++ b/app/app/src/main/res/values-en/strings.xml
@@ -97,6 +97,22 @@
     <string name="cheat_risk_title">Risk &amp; Reward</string>
     <string name="cheat_risk_desc">Cheating is dangerous! Use this advantage wisely to save yourself as a gold digger or to advance unnoticed as a saboteur. Make sure no one sees you triggering the sensor!</string>
 
+    <!-- Round Results -->
+    <string name="round_result_title">Round %1$d ended</string>
+    <string name="round_result_winner_golddiggers">Golddiggers win</string>
+    <string name="round_result_winner_saboteurs">Saboteurs win</string>
+    <string name="round_result_roles_title">Roles this round</string>
+    <string name="role_golddigger_label">Golddigger</string>
+    <string name="role_saboteur_label">Saboteur</string>
+    <string name="role_unknown_label">Unknown</string>
+    <string name="next_round_button_label">Continue to next round</string>
+
+    <!-- Final Results -->
+    <string name="final_result_title">🏆 Game ended</string>
+    <string name="final_result_roles_title">Roles of the last round</string>
+    <string name="final_result_gold_title">Final gold score</string>
+    <string name="final_result_winner_msg">🏆 %1$s wins with %2$d gold pieces</string>
+
     <!-- Menu actions -->
     <string name="menu_toggle">Open/close menu</string>
     <string name="leave_game">Leave Game</string>

--- a/app/app/src/main/res/values/strings.xml
+++ b/app/app/src/main/res/values/strings.xml
@@ -97,6 +97,22 @@
     <string name="cheat_risk_title">Risk &amp; Reward</string>
     <string name="cheat_risk_desc">Cheating is dangerous! Use this advantage wisely to save yourself as a gold digger or to advance unnoticed as a saboteur. Make sure no one sees you triggering the sensor!</string>
 
+    <!-- Round Results -->
+    <string name="round_result_title">Runde %1$d beendet</string>
+    <string name="round_result_winner_golddiggers">Goldsucher gewinnen</string>
+    <string name="round_result_winner_saboteurs">Saboteure gewinnen</string>
+    <string name="round_result_roles_title">Rollen dieser Runde</string>
+    <string name="role_golddigger_label">Goldsucher</string>
+    <string name="role_saboteur_label">Saboteur</string>
+    <string name="role_unknown_label">Unbekannt</string>
+    <string name="next_round_button_label">Weiter zur nächsten Runde</string>
+
+    <!-- Final Results -->
+    <string name="final_result_title">🏆 Spiel beendet</string>
+    <string name="final_result_roles_title">Rollen der letzten Runde</string>
+    <string name="final_result_gold_title">Endgültiger Goldstand</string>
+    <string name="final_result_winner_msg">🏆 %1$s gewinnt mit %2$d Goldstücken</string>
+
     <!-- Menu actions -->
     <string name="menu_toggle">Menü öffnen/schließen</string>
     <string name="leave_game">Spiel verlassen</string>


### PR DESCRIPTION
# Refactor: Internationalisierung für Endrunden- und Ergebnis-Anzeige

## Übersicht
Dieser PR behebt das Problem, dass die Ergebnisse der Endrunde und die abschließende Spielauswertung hartcodiert auf Deutsch waren, wodurch die Sprachwahl des Nutzers ignoriert wurde. Beide Screens (`RoundResultScreen.kt` und `FinalResultScreen.kt`) wurden nun vollständig auf das vorhandene i18n-System umgestellt.

## Wichtige Änderungen

### 1. Ressourcen-Extraktion
- Alle UI-Texte wurden aus dem Kotlin-Quellcode in die `strings.xml`-Dateien verschoben.
- Es wurden entsprechende Einträge für Deutsch (Standard-Fallback) und Englisch (`values-en`) erstellt.
- Verwendung von Platzhaltern (`%1$d`, `%1$s`) zur sauberen Handhabung von dynamischen Werten wie Rundenzahlen, Spielernamen und Goldbeträgen.

### 2. UI-Refactoring
- **RoundResultScreen:** Alle hartcodierten Labels durch `stringResource` ersetzt. `CompositionLocalProvider` wurde integriert, um sicherzustellen, dass der lokalisierte Kontext korrekt verwendet wird.
- **FinalResultScreen:** Überarbeitung zur Unterstützung der dynamischen Lokalisierung. Dies stellt sicher, dass Gewinner-Ankündigungen und Gold-Zusammenfassungen korrekt bei Sprachwechseln aktualisiert werden.
- **Robustheit:** Hinzufügen von Fallbacks (z.B. `role_unknown_label`), falls Rollen- oder Spielerdaten kurzzeitig nicht verfügbar sein sollten.

### 3. Lokalisierungs-Logik
- Vereinheitlichung der Nutzung von `LanguageManager` und `rememberLocalizedContext` über beide Screens hinweg, um ein konsistentes Verhalten im gesamten End-Game-Bereich zu gewährleisten.

## Testumfang
- Überprüfung, ob die Texte beim Wechsel der Sprache im `LanguageManager` korrekt zwischen Deutsch und Englisch umschalten.
- Verifizierung der dynamischen Platzhalter (Rundennummer, Goldbeträge) in beiden Sprachen.
- Sicherstellung, dass das UI-Layout nach der Umstellung auf Ressourcen-Strings stabil bleibt.