### PR TITLE
feat: add CI workflow for automated release builds

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,47 +1,53 @@
 name: Android Release Build
 
 on:
-  push:
-    tags:
-      - 'v*'
+push:
+tags:
+  - 'v*'
 
 permissions:
-  contents: write
+contents: write
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+build:
+runs-on: ubuntu-latest
+  
+  ```
+steps:
+  - uses: actions/checkout@v4
 
-    steps:
-      - uses: actions/checkout@v4
+  - name: Set up JDK 17
+    uses: actions/setup-java@v4
+    with:
+      java-version: '17'
+      distribution: 'temurin'
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: temurin
+  - name: Build Release APK
+    run: ./gradlew assembleRelease
 
-      - name: Build Release APK
-        run: ./gradlew assembleRelease
+  - name: Rename APK with Commit Hash
+    shell: bash
+    run: |
+      APK_PATH=$(find . -path "*/release/*.apk" | head -n 1)
 
-      - name: Rename APK with Commit Hash
-        run: |
-          APK_PATH=$(find . -path "*/release/*.apk" | head -n 1)
+      if [ -z "$APK_PATH" ]; then
+        echo "Keine APK gefunden!"
+        exit 1
+      fi
 
-          if [ -z "$APK_PATH" ]; then
-            echo "Keine APK gefunden!"
-            exit 1
-          fi
+      COMMIT_HASH=$(git rev-parse --short HEAD)
+      NEW_NAME="Saboteur-${{ github.ref_name }}-${COMMIT_HASH}.apk"
 
-          COMMIT_HASH=$(git rev-parse --short HEAD)
-          NEW_NAME="Saboteur-${{ github.ref_name }}-${COMMIT_HASH}.apk"
+      mv "$APK_PATH" "./$NEW_NAME"
 
-          mv "$APK_PATH" "./$NEW_NAME"
-          echo "APK_FILE=$NEW_NAME" >> "$GITHUB_ENV"
+      echo "APK_FILE=$NEW_NAME" >> "$GITHUB_ENV"
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: ${{ env.APK_FILE }}
-          generate_release_notes: true
-          name: Release ${{ github.ref_name }} (Commit: ${{ github.sha }})
+  - name: Create GitHub Release
+    uses: softprops/action-gh-release@v2
+    with:
+      files: ${{ env.APK_FILE }}
+      generate_release_notes: true
+      name: "Release ${{ github.ref_name }} (Commit: ${{ github.sha }})"
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -18,32 +19,29 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'temurin'
+          distribution: temurin
 
       - name: Build Release APK
         run: ./gradlew assembleRelease
 
       - name: Rename APK with Commit Hash
         run: |
-          # Finde die APK Datei egal wo sie liegt
-          APK_PATH=$(find . -name "app-release.apk" | head -n 1)
+          APK_PATH=$(find . -path "*/release/*.apk" | head -n 1)
+
           if [ -z "$APK_PATH" ]; then
-            echo "Keine app-release.apk gefunden!"
+            echo "Keine APK gefunden!"
             exit 1
           fi
-          
+
           COMMIT_HASH=$(git rev-parse --short HEAD)
-          NEW_NAME="Saboteur-v${{ github.ref_name }}-${COMMIT_HASH}.apk"
-          
-          # Verschiebe sie in das Root-Verzeichnis, damit der Upload einfach ist
+          NEW_NAME="Saboteur-${{ github.ref_name }}-${COMMIT_HASH}.apk"
+
           mv "$APK_PATH" "./$NEW_NAME"
-          echo "APK_FILE=$NEW_NAME" >> $GITHUB_ENV
+          echo "APK_FILE=$NEW_NAME" >> "$GITHUB_ENV"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.APK_FILE }}
           generate_release_notes: true
           name: Release ${{ github.ref_name }} (Commit: ${{ github.sha }})
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -23,12 +23,27 @@ jobs:
       - name: Build Release APK
         run: ./gradlew assembleRelease
 
+      - name: Rename APK with Commit Hash
+        run: |
+          # Finde die APK Datei egal wo sie liegt
+          APK_PATH=$(find . -name "app-release.apk" | head -n 1)
+          if [ -z "$APK_PATH" ]; then
+            echo "Keine app-release.apk gefunden!"
+            exit 1
+          fi
+          
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          NEW_NAME="Saboteur-v${{ github.ref_name }}-${COMMIT_HASH}.apk"
+          
+          # Verschiebe sie in das Root-Verzeichnis, damit der Upload einfach ist
+          mv "$APK_PATH" "./$NEW_NAME"
+          echo "APK_FILE=$NEW_NAME" >> $GITHUB_ENV
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          files: |
-            app/build/outputs/apk/release/*.apk
-            app/build/outputs/apk/release/app-release.apk
+          files: ${{ env.APK_FILE }}
           generate_release_notes: true
+          name: Release ${{ github.ref_name }} (Commit: ${{ github.sha }})
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -47,7 +47,7 @@ steps:
     with:
       files: ${{ env.APK_FILE }}
       generate_release_notes: true
-      name: "Release ${{ github.ref_name }} (Commit: ${{ github.sha }})"
+      name: Release ${{ github.ref_name }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -3,14 +3,16 @@ name: Android Release Build
 on:
   push:
     tags:
-      - 'v*' # Startet den Build, wenn du einen Tag wie 'v1.0' pushst
+      - 'v*'
+
+permissions:
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -18,17 +20,15 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
       - name: Build Release APK
         run: ./gradlew assembleRelease
-
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          files: app/build/outputs/apk/release/*.apk
+          files: |
+            app/build/outputs/apk/release/*.apk
+            app/build/outputs/apk/release/app-release.apk
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,34 @@
+name: Android Release Build
+
+on:
+  push:
+    tags:
+      - 'v*' # Startet den Build, wenn du einen Tag wie 'v1.0' pushst
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build Release APK
+        run: ./gradlew assembleRelease
+
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: app/build/outputs/apk/release/*.apk
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,53 +1,51 @@
 name: Android Release Build
 
 on:
-push:
-tags:
-  - 'v*'
+  push:
+    tags:
+      - 'v*'
 
 permissions:
-contents: write
+  contents: write
 
 jobs:
-build:
-runs-on: ubuntu-latest
-  
-  ```
-steps:
-  - uses: actions/checkout@v4
+  build:
+    runs-on: ubuntu-latest
 
-  - name: Set up JDK 17
-    uses: actions/setup-java@v4
-    with:
-      java-version: '17'
-      distribution: 'temurin'
+    steps:
+      - uses: actions/checkout@v4
 
-  - name: Build Release APK
-    run: ./gradlew assembleRelease
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-  - name: Rename APK with Commit Hash
-    shell: bash
-    run: |
-      APK_PATH=$(find . -path "*/release/*.apk" | head -n 1)
+      - name: Build Release APK
+        run: ./gradlew assembleRelease
 
-      if [ -z "$APK_PATH" ]; then
-        echo "Keine APK gefunden!"
-        exit 1
-      fi
+      - name: Rename APK with Commit Hash
+        shell: bash
+        run: |
+          APK_PATH=$(find . -path "*/release/*.apk" | head -n 1)
 
-      COMMIT_HASH=$(git rev-parse --short HEAD)
-      NEW_NAME="Saboteur-${{ github.ref_name }}-${COMMIT_HASH}.apk"
+          if [ -z "$APK_PATH" ]; then
+            echo "Keine APK gefunden!"
+            exit 1
+          fi
 
-      mv "$APK_PATH" "./$NEW_NAME"
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          NEW_NAME="Saboteur-${{ github.ref_name }}-${COMMIT_HASH}.apk"
 
-      echo "APK_FILE=$NEW_NAME" >> "$GITHUB_ENV"
+          mv "$APK_PATH" "./$NEW_NAME"
 
-  - name: Create GitHub Release
-    uses: softprops/action-gh-release@v2
-    with:
-      files: ${{ env.APK_FILE }}
-      generate_release_notes: true
-      name: Release ${{ github.ref_name }}
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "APK_FILE=$NEW_NAME" >> "$GITHUB_ENV"
 
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.APK_FILE }}
+          generate_release_notes: true
+          name: "Release ${{ github.ref_name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/app/build.gradle.kts
+++ b/app/app/build.gradle.kts
@@ -1,10 +1,24 @@
 import java.util.Properties
+import java.io.ByteArrayOutputStream
 
 // 1. Properties-Lader: Liest die lokale Konfiguration aus local.properties
 val localProperties = Properties()
 val localPropertiesFile = rootProject.file("local.properties")
 if (localPropertiesFile.exists()) {
     localProperties.load(localPropertiesFile.inputStream())
+}
+
+
+// 2. Git Commit-Hash Helper (Sichere Java-Prozess-Variante)
+val gitCommit = try {
+    val process = ProcessBuilder("git", "rev-parse", "--short", "HEAD")
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+
+    process.inputStream.bufferedReader().readText().trim()
+} catch (e: Exception) {
+    "unknown"
 }
 
 plugins {
@@ -23,9 +37,12 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 1
-        versionName = "1.0"
+        versionName = "1.0.$gitCommit"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        // Git Commit-Hash als BuildConfig Feld verfügbar machen
+        buildConfigField("String", "COMMIT_HASH", "\"$gitCommit\"")
     }
 
     buildFeatures {
@@ -34,23 +51,22 @@ android {
     }
 
     buildTypes {
-        debug {
-            // 2. Dynamische URL: Nimmt Wert aus local.properties oder Fallback auf Emulator-IP
+        getByName("debug") {
             val baseUrl = localProperties.getProperty("BASE_URL_LOCAL") ?: "http://10.0.2.2:8080"
             buildConfigField("String", "BASE_URL", "\"$baseUrl\"")
-
             enableUnitTestCoverage = true
         }
-        release {
+        getByName("release") {
             isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            // 3. Feste URL für den Uni-Server (Produktion)
             buildConfigField("String", "BASE_URL", "\"http://se2-demo.aau.at:53207\"")
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
@@ -129,7 +145,7 @@ val jacocoTestDebugUnitTestReport by tasks.registering(JacocoReport::class) {
     )
 
     sourceDirectories.setFrom(files("${project.projectDir}/src/main/java", "${project.projectDir}/src/main/kotlin"))
-    
+
     val kotlinTree = fileTree("$buildDir/intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes") {
         exclude(fileFilter)
     }


### PR DESCRIPTION
Dieser PR führt eine automatisierte Build-Pipeline mittels GitHub Actions ein. Ziel ist es, den manuellen Aufwand für die Erstellung von Release-APK-Dateien zu eliminieren und eine einfache Verteilung von Test-Builds zu ermöglichen.

Wichtige Änderungen
Workflow-Konfiguration: Neue Datei .github/workflows/android-release.yml hinzugefügt.

Trigger-Mechanismus: Die Pipeline wird automatisch ausgelöst, sobald ein Tag mit dem Muster v* (z.B. v1.0.0) in das Repository gepusht wird.

Build-Prozess: * Nutzt ein Ubuntu-Environment mit Java 17.

Führt den Gradle-Task assembleRelease aus.

Da kein expliziter Signing-Block in der build.gradle konfiguriert ist, wird die Release-APK automatisch mit dem Standard-Debug-Keystore signiert (perfekt für interne Test-Verteilungen).

Release-Management: Verwendet softprops/action-gh-release, um die gebaute APK direkt in den Bereich "Releases" auf GitHub hochzuladen und automatisch Release-Notes zu generieren.

Vorteile
Effizienz: Kein manuelles Bauen und Hochladen der APKs mehr nötig.

Nachvollziehbarkeit: Jedes Release ist über die Git-Historie (Tags) direkt mit dem entsprechenden Code-Stand verknüpft.

Test-Verfügbarkeit: Teammitglieder können jederzeit die neueste APK-Version direkt von GitHub herunterladen, ohne auf ein lokales Build-Environment angewiesen zu sein.

Test-Anweisungen
PR mergen oder Branch direkt testen.

Einen neuen Tag auf dem Branch setzen: git tag v0.1.0-test && git push origin v0.1.0-test.

Im Tab "Actions" auf GitHub prüfen, ob der Build startet.

Nach Abschluss unter "Releases" die generierte APK herunterladen.