### PR TITLE
Fix: Ladebildschirm nach 'Spiel verlassen' am Ende des Spiels

### DIFF
--- a/app/app/src/main/java/com/aau/saboteur/navigation/AppNavHost.kt
+++ b/app/app/src/main/java/com/aau/saboteur/navigation/AppNavHost.kt
@@ -96,7 +96,12 @@ fun AppNavHost(
                         navController.navigate("game")
                     },
                     onLeaveLobby = {
-                        navController.popBackStack()
+                        val currentUsername = lobbyViewModel.username.value
+                        if (!navController.popBackStack()) {
+                            navController.navigate("lobby/$currentUsername") {
+                                popUpTo(0) { inclusive = true }
+                            }
+                        }
                     }
                 )
             }
@@ -115,7 +120,7 @@ fun AppNavHost(
                         val username = lobbyViewModel.username.value
                         GameApi.reset()
                         navController.navigate("activeLobby/$username") {
-                            popUpTo(0) { inclusive = true }
+                            popUpTo("lobby/$username") { inclusive = false }
                         }
                     }
                 )


### PR DESCRIPTION
## Problem

Nach der dritten Runde endet das Spiel und der Spieler drückt „Zurück zur Lobby". Anschließend öffnet er das Menü und klickt „Spiel verlassen" — danach bleibt er dauerhaft im Ladebildschirm mit der Meldung **„Zustand wird synchronisiert..."** hängen.

## Ursache

Die Navigation nach dem Spielende rief `onBackToActiveLobby` mit `popUpTo(0) { inclusive = true }` auf. Das löschte den **gesamten** Back-Stack, sodass nur noch `activeLobby/$username` als einziger Eintrag übrig blieb.

Wenn der Spieler danach „Spiel verlassen" drückte, setzte `leaveLobby()` den `lobbyState` auf `null`. Der `HandleActiveLobbyEffects`-LaunchedEffect reagierte darauf und rief `onLeaveLobby()` auf, das intern `navController.popBackStack()` aufrief. Da aber kein Eintrag mehr im Stack vorhanden war, **scheiterte `popBackStack()` lautlos** (Rückgabewert `false`) — der Spieler blieb auf dem `ActiveLobbyScreen` mit dem Sync-Overlay stecken.

## Lösung

**`AppNavHost.kt` — zwei Änderungen:**

1. **`onBackToActiveLobby`**: `popUpTo(0) { inclusive = true }` durch `popUpTo("lobby/$username") { inclusive = false }` ersetzt. Der `lobby`-Screen bleibt damit im Back-Stack erhalten, sodass `popBackStack()` von `activeLobby` immer ein valides Ziel hat.

2. **`onLeaveLobby`**: Fallback eingebaut — gibt `popBackStack()` `false` zurück (leerer Stack), wird direkt zu `lobby/$currentUsername` navigiert. Das sichert auch edge cases ab, in denen der User über andere Pfade auf den `activeLobby`-Screen gelangt.

## Testplan

- [ ] Spiel normal bis zur dritten Runde spielen
- [ ] „Zurück zur Lobby" auf dem Endergebnis-Screen drücken
- [ ] Auf dem ActiveLobbyScreen Menü öffnen → „Spiel verlassen" drücken
- [ ] Prüfen: Navigation landet auf dem Lobby-Listen-Screen, kein Ladebildschirm
- [ ] Normalen Lobby-Verlassen-Flow (mitten im Spiel) testen — kein Regressionsfehler
- [ ] Direkt aus der ActiveLobby verlassen (ohne vorheriges Spiel) testen